### PR TITLE
Make optional properties return None while uninitialized.

### DIFF
--- a/nmigen_soc/csr/bus.py
+++ b/nmigen_soc/csr/bus.py
@@ -109,8 +109,6 @@ class Interface(Record):
 
     Attributes
     ----------
-    memory_map : MemoryMap
-        Map of the bus.
     addr : Signal(addr_width)
         Address for reads and writes.
     r_data : Signal(data_width)
@@ -151,9 +149,21 @@ class Interface(Record):
 
     @property
     def memory_map(self):
-        if self._map is None:
-            raise NotImplementedError("Bus interface {!r} does not have a memory map"
-                                      .format(self))
+        """Map of the bus.
+
+        See :class:`..memory.MemoryMap` for details.
+
+        Return value
+        ------------
+        A :class:`~..memory.MemoryMap` describing the target address space, or ``None`` if the
+        interface does not have a memory map.
+
+        Exceptions
+        ----------
+        Raises :exn:`ValueError` if the setter is called with a memory map whose address width is
+        not equal to the interface address width, or whose data width is not equal to the interface
+        data width.
+        """
         return self._map
 
     @memory_map.setter
@@ -370,6 +380,9 @@ class Decoder(Elaboratable):
             raise ValueError("Subordinate bus has data width {}, which is not the same as "
                              "decoder data width {}"
                              .format(sub_bus.data_width, self._map.data_width))
+
+        if sub_bus.memory_map is None:
+            raise ValueError("Subordinate bus does not have a memory map")
         self._subs[sub_bus.memory_map] = sub_bus
         return self._map.add_window(sub_bus.memory_map, addr=addr, extend=extend)
 

--- a/nmigen_soc/csr/wishbone.py
+++ b/nmigen_soc/csr/wishbone.py
@@ -53,6 +53,9 @@ class WishboneCSRBridge(Elaboratable):
         self.wb_bus.memory_map = MemoryMap(addr_width=csr_bus.addr_width,
                                            data_width=csr_bus.data_width)
 
+        if self.csr_bus.memory_map is None:
+            raise ValueError("CSR bus does not have a memory map")
+
         # Since granularity of the Wishbone interface matches the data width of the CSR bus,
         # no width conversion is performed, even if the Wishbone data width is greater.
         self.wb_bus.memory_map.add_window(self.csr_bus.memory_map)

--- a/nmigen_soc/event.py
+++ b/nmigen_soc/event.py
@@ -49,15 +49,9 @@ class Source(Record):
 
         Return value
         ------------
-        A :class:`EventMap` describing subordinate event sources.
-
-        Exceptions
-        ----------
-        Raises :exn:`NotImplementedError` if the source does not have an event map.
+        An :class:`EventMap` describing subordinate event sources, or ``None`` if the source does
+        not have an event map.
         """
-        if self._map is None:
-            raise NotImplementedError("Event source {!r} does not have an event map"
-                                      .format(self))
         return self._map
 
     @event_map.setter

--- a/nmigen_soc/periph.py
+++ b/nmigen_soc/periph.py
@@ -176,16 +176,9 @@ class PeripheralInfo:
 
         Return value
         ------------
-        An :class:`event.Source` used by the peripheral to request interrupts. If provided, its
-        event map describes local events.
-
-        Exceptions
-        ----------
-        Raises :exn:`NotImplementedError` if the peripheral info does not have an IRQ line.
+        An :class:`event.Source` used by the peripheral to request interrupts, or ``None`` if the
+        peripheral does not have an IRQ line. If provided, its event map describes local events.
         """
-        if self._irq is None:
-            raise NotImplementedError("Peripheral info does not have an IRQ line"
-                                      .format(self))
         return self._irq
 
     @property

--- a/nmigen_soc/test/test_csr_bus.py
+++ b/nmigen_soc/test/test_csr_bus.py
@@ -84,12 +84,9 @@ class InterfaceTestCase(unittest.TestCase):
                 r"Data width must be a positive integer, not -1"):
             Interface(addr_width=16, data_width=-1)
 
-    def test_get_map_wrong(self):
+    def test_get_map_none(self):
         iface = Interface(addr_width=16, data_width=8)
-        with self.assertRaisesRegex(NotImplementedError,
-                r"Bus interface \(rec iface addr r_data r_stb w_data w_stb\) does not "
-                r"have a memory map"):
-            iface.memory_map
+        self.assertEqual(iface.memory_map, None)
 
     def test_get_map_frozen(self):
         iface = Interface(addr_width=16, data_width=8)
@@ -349,6 +346,12 @@ class DecoderTestCase(unittest.TestCase):
         with self.assertRaisesRegex(ValueError,
                 r"Address range 0x0\.\.0x20000 out of bounds for memory map spanning "
                 r"range 0x0\.\.0x10000 \(16 address bits\)"):
+            self.dut.add(iface)
+
+    def test_add_wrong_no_map(self):
+        iface = Interface(addr_width=10, data_width=8)
+        with self.assertRaisesRegex(ValueError,
+                r"Subordinate bus does not have a memory map"):
             self.dut.add(iface)
 
     def test_sim(self):

--- a/nmigen_soc/test/test_csr_wishbone.py
+++ b/nmigen_soc/test/test_csr_wishbone.py
@@ -5,6 +5,7 @@ from nmigen import *
 from nmigen.back.pysim import *
 
 from .. import csr
+from ..memory import MemoryMap
 from ..csr.wishbone import *
 
 
@@ -36,9 +37,17 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             WishboneCSRBridge("foo")
 
     def test_wrong_csr_bus_data_width(self):
+        csr_bus = csr.Interface(addr_width=10, data_width=7)
+        csr_bus.memory_map = MemoryMap(addr_width=10, data_width=7)
         with self.assertRaisesRegex(ValueError,
                 r"CSR bus data width must be one of 8, 16, 32, 64, not 7"):
-            WishboneCSRBridge(csr_bus=csr.Interface(addr_width=10, data_width=7))
+            WishboneCSRBridge(csr_bus)
+
+    def test_wrong_csr_bus_no_map(self):
+        csr_bus = csr.Interface(addr_width=10, data_width=8)
+        with self.assertRaisesRegex(ValueError,
+                r"CSR bus does not have a memory map"):
+            WishboneCSRBridge(csr_bus)
 
     def test_narrow(self):
         mux   = csr.Multiplexer(addr_width=10, data_width=8)

--- a/nmigen_soc/test/test_event.py
+++ b/nmigen_soc/test/test_event.py
@@ -33,11 +33,9 @@ class SourceTestCase(unittest.TestCase):
                 r"Invalid trigger mode 'foo'; must be one of level, rise, fall"):
             src = Source(trigger="foo")
 
-    def test_get_map_wrong(self):
+    def test_get_map_none(self):
         src = Source()
-        with self.assertRaisesRegex(NotImplementedError,
-                r"Event source \(rec src i trg\) does not have an event map"):
-            src.event_map
+        self.assertEqual(src.event_map, None)
 
     def test_get_map_frozen(self):
         src = Source()

--- a/nmigen_soc/test/test_periph.py
+++ b/nmigen_soc/test/test_periph.py
@@ -122,16 +122,12 @@ class PeripheralInfoTestCase(unittest.TestCase):
     def test_irq_none(self):
         memory_map = MemoryMap(addr_width=1, data_width=8)
         info = PeripheralInfo(memory_map=memory_map, irq=None)
-        with self.assertRaisesRegex(NotImplementedError,
-                r"Peripheral info does not have an IRQ line"):
-            info.irq
+        self.assertEqual(info.irq, None)
 
     def test_irq_default(self):
         memory_map = MemoryMap(addr_width=1, data_width=8)
         info = PeripheralInfo(memory_map=memory_map)
-        with self.assertRaisesRegex(NotImplementedError,
-                r"Peripheral info does not have an IRQ line"):
-            info.irq
+        self.assertEqual(info.irq, None)
 
     def test_irq_wrong(self):
         memory_map = MemoryMap(addr_width=1, data_width=8)

--- a/nmigen_soc/test/test_wishbone_bus.py
+++ b/nmigen_soc/test/test_wishbone_bus.py
@@ -87,12 +87,9 @@ class InterfaceTestCase(unittest.TestCase):
                 r"Optional signal\(s\) 'foo' are not supported"):
             Interface(addr_width=0, data_width=8, features={"foo"})
 
-    def test_get_map_wrong(self):
+    def test_get_map_none(self):
         iface = Interface(addr_width=0, data_width=8)
-        with self.assertRaisesRegex(NotImplementedError,
-                r"Bus interface \(rec iface adr dat_w dat_r sel cyc stb we ack\) does "
-                r"not have a memory map"):
-            iface.memory_map
+        self.assertEqual(iface.memory_map, None)
 
     def test_get_map_frozen(self):
         iface = Interface(addr_width=1, data_width=8)
@@ -179,6 +176,12 @@ class DecoderTestCase(unittest.TestCase):
             r"Address range 0x1\.\.0x100000001 out of bounds for memory map spanning "
             r"range 0x0\.\.0x100000000 \(32 address bits\)"):
             self.dut.add(sub, addr=1)
+
+    def test_add_wrong_no_map(self):
+        sub = Interface(addr_width=31, data_width=32, granularity=16)
+        with self.assertRaisesRegex(ValueError,
+                r"Subordinate bus does not have a memory map"):
+            self.dut.add(sub)
 
 
 class DecoderSimulationTestCase(unittest.TestCase):


### PR DESCRIPTION
The previous behaviour was to raise a NotImplementedError. It is now the
responsibility of the caller to check if the property was initialized or
not.

Affected properties:
* wishbone.Interface.memory_map
* csr.Interface.memory_map
* event.Source.event_map
* periph.PeripheralInfo.irq