### PR TITLE
wishbone.bus: migrate to lib.wiring interfaces.

### DIFF
--- a/amaranth_soc/csr/wishbone.py
+++ b/amaranth_soc/csr/wishbone.py
@@ -2,7 +2,7 @@ from amaranth import *
 from amaranth.utils import log2_int
 
 from . import Interface as CSRInterface
-from ..wishbone import Interface as WishboneInterface
+from .. import wishbone
 from ..memory import MemoryMap
 
 
@@ -46,11 +46,11 @@ class WishboneCSRBridge(Elaboratable):
             data_width = csr_bus.data_width
 
         self.csr_bus = csr_bus
-        self.wb_bus  = WishboneInterface(
+        self.wb_bus  = wishbone.Signature(
             addr_width=max(0, csr_bus.addr_width - log2_int(data_width // csr_bus.data_width)),
             data_width=data_width,
-            granularity=csr_bus.data_width,
-            name="wb")
+            granularity=csr_bus.data_width).create()
+
 
         wb_map = MemoryMap(addr_width=csr_bus.addr_width, data_width=csr_bus.data_width,
                            name=name)

--- a/tests/test_wishbone_bus.py
+++ b/tests/test_wishbone_bus.py
@@ -2,100 +2,154 @@
 
 import unittest
 from amaranth import *
-from amaranth.hdl.rec import *
+from amaranth.lib.wiring import *
 from amaranth.sim import *
 
-from amaranth_soc.wishbone.bus import *
+from amaranth_soc import wishbone
 from amaranth_soc.memory import MemoryMap
 
 
-class InterfaceTestCase(unittest.TestCase):
+class SignatureTestCase(unittest.TestCase):
     def test_simple(self):
-        iface = Interface(addr_width=32, data_width=8)
-        self.assertEqual(iface.addr_width, 32)
-        self.assertEqual(iface.data_width, 8)
-        self.assertEqual(iface.granularity, 8)
-        self.assertEqual(iface.layout, Layout.cast([
-            ("adr",   32, DIR_FANOUT),
-            ("dat_w", 8,  DIR_FANOUT),
-            ("dat_r", 8,  DIR_FANIN),
-            ("sel",   1,  DIR_FANOUT),
-            ("cyc",   1,  DIR_FANOUT),
-            ("stb",   1,  DIR_FANOUT),
-            ("we",    1,  DIR_FANOUT),
-            ("ack",   1,  DIR_FANIN),
-        ]))
+        sig = wishbone.Signature(addr_width=32, data_width=8)
+        self.assertEqual(sig.addr_width, 32)
+        self.assertEqual(sig.data_width,  8)
+        self.assertEqual(sig.granularity, 8)
+        self.assertEqual(sig.members, Signature({
+            "adr":   Out(32),
+            "dat_w": Out(8),
+            "dat_r": In(8),
+            "sel":   Out(1),
+            "cyc":   Out(1),
+            "stb":   Out(1),
+            "we":    Out(1),
+            "ack":   In(1),
+        }).members)
 
     def test_granularity(self):
-        iface = Interface(addr_width=30, data_width=32, granularity=8)
-        self.assertEqual(iface.addr_width, 30)
-        self.assertEqual(iface.data_width, 32)
-        self.assertEqual(iface.granularity, 8)
-        self.assertEqual(iface.layout, Layout.cast([
-            ("adr",   30, DIR_FANOUT),
-            ("dat_w", 32, DIR_FANOUT),
-            ("dat_r", 32, DIR_FANIN),
-            ("sel",   4,  DIR_FANOUT),
-            ("cyc",   1,  DIR_FANOUT),
-            ("stb",   1,  DIR_FANOUT),
-            ("we",    1,  DIR_FANOUT),
-            ("ack",   1,  DIR_FANIN),
-        ]))
+        sig = wishbone.Signature(addr_width=30, data_width=32, granularity=8)
+        self.assertEqual(sig.addr_width, 30)
+        self.assertEqual(sig.data_width, 32)
+        self.assertEqual(sig.granularity, 8)
+        self.assertEqual(sig.members, Signature({
+            "adr":   Out(30),
+            "dat_w": Out(32),
+            "dat_r": In(32),
+            "sel":   Out(4),
+            "cyc":   Out(1),
+            "stb":   Out(1),
+            "we":    Out(1),
+            "ack":   In(1),
+        }).members)
 
     def test_features(self):
-        iface = Interface(addr_width=32, data_width=32,
-                          features={"rty", "err", "stall", "lock", "cti", "bte"})
-        self.assertEqual(iface.layout, Layout.cast([
-            ("adr",   32, DIR_FANOUT),
-            ("dat_w", 32, DIR_FANOUT),
-            ("dat_r", 32, DIR_FANIN),
-            ("sel",   1,  DIR_FANOUT),
-            ("cyc",   1,  DIR_FANOUT),
-            ("stb",   1,  DIR_FANOUT),
-            ("we",    1,  DIR_FANOUT),
-            ("ack",   1,  DIR_FANIN),
-            ("err",   1,  DIR_FANIN),
-            ("rty",   1,  DIR_FANIN),
-            ("stall", 1,  DIR_FANIN),
-            ("lock",  1,  DIR_FANOUT),
-            ("cti",   CycleType,    DIR_FANOUT),
-            ("bte",   BurstTypeExt, DIR_FANOUT),
-        ]))
+        sig = wishbone.Signature(addr_width=32, data_width=32,
+                                 features={"rty", "err", "stall", "lock", "cti", "bte"})
+        self.assertEqual(sig.members, Signature({
+            "adr":   Out(32),
+            "dat_w": Out(32),
+            "dat_r": In(32),
+            "sel":   Out(1),
+            "cyc":   Out(1),
+            "stb":   Out(1),
+            "we":    Out(1),
+            "ack":   In(1),
+            "err":   In(1),
+            "rty":   In(1),
+            "stall": In(1),
+            "lock":  Out(1),
+            "cti":   Out(wishbone.CycleType),
+            "bte":   Out(wishbone.BurstTypeExt),
+        }).members)
+
+    def test_eq(self):
+        self.assertEqual(wishbone.Signature(addr_width=32, data_width=8, features={"err"}),
+                         wishbone.Signature(addr_width=32, data_width=8, features={"err"}))
+        # different addr_width
+        self.assertNotEqual(wishbone.Signature(addr_width=16, data_width=16, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=8))
+        # different data_width
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=8, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=8))
+        # different granularity
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=16, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=16))
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=16, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16))
+        # different features
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=16, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=8,
+                                               features={"err"}))
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=16, granularity=8,
+                                               features={"rty"}),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=8,
+                                               features={"err"}))
+
+    def test_create(self):
+        sig   = wishbone.Signature(addr_width=32, data_width=16, granularity=8)
+        iface = sig.create()
+        self.assertIsInstance(iface, wishbone.Interface)
+        self.assertEqual(iface.addr_width, 32)
+        self.assertEqual(iface.data_width, 16)
+        self.assertEqual(iface.granularity, 8)
+        self.assertIs(iface.signature, sig)
 
     def test_wrong_addr_width(self):
-        with self.assertRaisesRegex(ValueError,
+        with self.assertRaisesRegex(TypeError,
                 r"Address width must be a non-negative integer, not -1"):
-            Interface(addr_width=-1, data_width=8)
+            wishbone.Signature(addr_width=-1, data_width=8)
+        with self.assertRaisesRegex(TypeError,
+                r"Address width must be a non-negative integer, not -1"):
+            wishbone.Signature.check(addr_width=-1, data_width=8, granularity=8, features=())
 
     def test_wrong_data_width(self):
         with self.assertRaisesRegex(ValueError,
                 r"Data width must be one of 8, 16, 32, 64, not 7"):
-            Interface(addr_width=0, data_width=7)
+            wishbone.Signature(addr_width=0, data_width=7)
+        with self.assertRaisesRegex(ValueError,
+                r"Data width must be one of 8, 16, 32, 64, not 7"):
+            wishbone.Signature.check(addr_width=0, data_width=7, granularity=7, features=())
 
     def test_wrong_granularity(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity must be one of 8, 16, 32, 64, not 7"):
-            Interface(addr_width=0, data_width=32, granularity=7)
+            wishbone.Signature(addr_width=0, data_width=32, granularity=7)
+        with self.assertRaisesRegex(ValueError,
+                r"Granularity must be one of 8, 16, 32, 64, not 7"):
+            wishbone.Signature.check(addr_width=0, data_width=32, granularity=7, features=())
 
     def test_wrong_granularity_wide(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity 32 may not be greater than data width 8"):
-            Interface(addr_width=0, data_width=8, granularity=32)
+            wishbone.Signature(addr_width=0, data_width=8, granularity=32)
+        with self.assertRaisesRegex(ValueError,
+                r"Granularity 32 may not be greater than data width 8"):
+            wishbone.Signature.check(addr_width=0, data_width=8, granularity=32, features=())
 
     def test_wrong_features(self):
-        with self.assertRaisesRegex(ValueError,
-                r"Optional signal\(s\) 'foo' are not supported"):
-            Interface(addr_width=0, data_width=8, features={"foo"})
+        with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
+            wishbone.Signature(addr_width=0, data_width=8, features={"foo"})
+        with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
+            wishbone.Signature.check(addr_width=0, data_width=8, granularity=8, features={"foo"})
+
+
+class InterfaceTestCase(unittest.TestCase):
+    def test_simple(self):
+        sig   = wishbone.Signature(addr_width=32, data_width=8)
+        iface = wishbone.Interface(sig)
+        self.assertEqual(iface.addr_width, 32)
+        self.assertEqual(iface.data_width, 8)
+        self.assertEqual(iface.granularity, 8)
+        self.assertIs(iface.signature, sig)
 
     def test_get_map_wrong(self):
-        iface = Interface(addr_width=0, data_width=8)
+        iface = wishbone.Signature(addr_width=0, data_width=8).create()
         with self.assertRaisesRegex(NotImplementedError,
-                r"Bus interface \(rec iface adr dat_w dat_r sel cyc stb we ack\) does "
-                r"not have a memory map"):
+                r"wishbone.Interface\(.*\) does not have a memory map"):
             iface.memory_map
 
     def test_get_map_frozen(self):
-        iface = Interface(addr_width=1, data_width=8)
+        iface = wishbone.Signature(addr_width=1, data_width=8).create()
         iface.memory_map = MemoryMap(addr_width=1, data_width=8)
         with self.assertRaisesRegex(ValueError,
                 r"Memory map has been frozen\. Address width cannot be extended "
@@ -103,20 +157,21 @@ class InterfaceTestCase(unittest.TestCase):
             iface.memory_map.addr_width = 2
 
     def test_set_map_wrong(self):
-        iface = Interface(addr_width=0, data_width=8)
+        sig   = wishbone.Signature(addr_width=0, data_width=8)
+        iface = wishbone.Interface(sig)
         with self.assertRaisesRegex(TypeError,
                 r"Memory map must be an instance of MemoryMap, not 'foo'"):
             iface.memory_map = "foo"
 
     def test_set_map_wrong_data_width(self):
-        iface = Interface(addr_width=30, data_width=32, granularity=8)
+        iface = wishbone.Signature(addr_width=30, data_width=32, granularity=8).create()
         with self.assertRaisesRegex(ValueError,
                 r"Memory map has data width 32, which is not the same as bus "
                 r"interface granularity 8"):
             iface.memory_map = MemoryMap(addr_width=32, data_width=32)
 
     def test_set_map_wrong_addr_width(self):
-        iface = Interface(addr_width=30, data_width=32, granularity=8)
+        iface = wishbone.Signature(addr_width=30, data_width=32, granularity=8).create()
         with self.assertRaisesRegex(ValueError,
                 r"Memory map has address width 30, which is not the same as bus "
                 r"interface address width 32 \(30 address bits \+ 2 granularity bits\)"):
@@ -125,12 +180,13 @@ class InterfaceTestCase(unittest.TestCase):
 
 class DecoderTestCase(unittest.TestCase):
     def setUp(self):
-        self.dut = Decoder(addr_width=31, data_width=32, granularity=16)
+        self.dut = wishbone.Decoder(addr_width=31, data_width=32, granularity=16)
 
     def test_add_align_to(self):
-        sub_1 = Interface(addr_width=15, data_width=32, granularity=16)
+        sig   = wishbone.Signature(addr_width=15, data_width=32, granularity=16)
+        sub_1 = wishbone.Interface(sig)
+        sub_2 = wishbone.Interface(sig)
         sub_1.memory_map = MemoryMap(addr_width=16, data_width=16)
-        sub_2 = Interface(addr_width=15, data_width=32, granularity=16)
         sub_2.memory_map = MemoryMap(addr_width=16, data_width=16)
         self.assertEqual(self.dut.add(sub_1), (0x00000000, 0x00010000, 1))
         self.assertEqual(self.dut.align_to(18), 0x000040000)
@@ -138,7 +194,7 @@ class DecoderTestCase(unittest.TestCase):
         self.assertEqual(self.dut.add(sub_2), (0x00040000, 0x00050000, 1))
 
     def test_add_extend(self):
-        sub = Interface(addr_width=31, data_width=32, granularity=16)
+        sub = wishbone.Signature(addr_width=31, data_width=32, granularity=16).create()
         sub.memory_map = MemoryMap(addr_width=32, data_width=16)
         self.assertEqual(self.dut.add(sub, addr=1, extend=True), (1, 0x100000001, 1))
         self.assertEqual(self.dut.bus.addr_width, 32)
@@ -149,31 +205,36 @@ class DecoderTestCase(unittest.TestCase):
             self.dut.add(sub_bus="foo")
 
     def test_add_wrong_granularity(self):
+        sub = wishbone.Signature(addr_width=15, data_width=32, granularity=32).create()
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has granularity 32, which is greater than "
                 r"the decoder granularity 16"):
-            self.dut.add(Interface(addr_width=15, data_width=32, granularity=32))
+            self.dut.add(sub)
 
     def test_add_wrong_width_dense(self):
+        sub = wishbone.Signature(addr_width=15, data_width=16, granularity=16).create()
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has data width 16, which is not the same as decoder "
                 r"data width 32 \(required for dense address translation\)"):
-            self.dut.add(Interface(addr_width=15, data_width=16, granularity=16))
+            self.dut.add(sub)
 
     def test_add_wrong_granularity_sparse(self):
+        sub = wishbone.Signature(addr_width=15, data_width=64, granularity=16).create()
         with self.assertRaisesRegex(ValueError,
-                r"Subordinate bus has data width 64, which is not the same as subordinate "
-                r"bus granularity 16 \(required for sparse address translation\)"):
-            self.dut.add(Interface(addr_width=15, data_width=64, granularity=16), sparse=True)
+                r"Subordinate bus has data width 64, which is not the same as its "
+                r"granularity 16 \(required for sparse address translation\)"):
+            self.dut.add(sub, sparse=True)
 
     def test_add_wrong_optional_output(self):
+        sig = wishbone.Signature(addr_width=15, data_width=32, granularity=16, features={"err"})
+        sub = wishbone.Interface(sig)
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has optional output 'err', but the decoder does "
                 r"not have a corresponding input"):
-            self.dut.add(Interface(addr_width=15, data_width=32, granularity=16, features={"err"}))
+            self.dut.add(sub)
 
     def test_add_wrong_out_of_bounds(self):
-        sub = Interface(addr_width=31, data_width=32, granularity=16)
+        sub = wishbone.Signature(addr_width=31, data_width=32, granularity=16).create()
         sub.memory_map = MemoryMap(addr_width=32, data_width=16)
         with self.assertRaisesRegex(ValueError,
             r"Address range 0x1\.\.0x100000001 out of bounds for memory map spanning "
@@ -183,13 +244,13 @@ class DecoderTestCase(unittest.TestCase):
 
 class DecoderSimulationTestCase(unittest.TestCase):
     def test_simple(self):
-        dut = Decoder(addr_width=30, data_width=32, granularity=8,
-                      features={"err", "rty", "stall", "lock", "cti", "bte"})
-        sub_1 = Interface(addr_width=14, data_width=32, granularity=8)
+        dut = wishbone.Decoder(addr_width=30, data_width=32, granularity=8,
+                               features={"err", "rty", "stall", "lock", "cti", "bte"})
+        sub_1 = wishbone.Signature(addr_width=14, data_width=32, granularity=8).create()
         sub_1.memory_map = MemoryMap(addr_width=16, data_width=8)
         dut.add(sub_1, addr=0x10000)
-        sub_2 = Interface(addr_width=14, data_width=32, granularity=8,
-                          features={"err", "rty", "stall", "lock", "cti", "bte"})
+        sub_2 = wishbone.Signature(addr_width=14, data_width=32, granularity=8,
+                                   features={"err", "rty", "stall", "lock", "cti", "bte"}).create()
         sub_2.memory_map = MemoryMap(addr_width=16, data_width=8)
         dut.add(sub_2)
 
@@ -200,8 +261,8 @@ class DecoderSimulationTestCase(unittest.TestCase):
             yield dut.bus.sel.eq(0b11)
             yield dut.bus.dat_w.eq(0x12345678)
             yield dut.bus.lock.eq(1)
-            yield dut.bus.cti.eq(CycleType.INCR_BURST)
-            yield dut.bus.bte.eq(BurstTypeExt.WRAP_4)
+            yield dut.bus.cti.eq(wishbone.CycleType.INCR_BURST)
+            yield dut.bus.bte.eq(wishbone.BurstTypeExt.WRAP_4)
             yield sub_1.ack.eq(1)
             yield sub_1.dat_r.eq(0xabcdef01)
             yield sub_2.dat_r.eq(0x5678abcd)
@@ -230,8 +291,8 @@ class DecoderSimulationTestCase(unittest.TestCase):
             self.assertEqual((yield sub_1.sel), 0b11)
             self.assertEqual((yield sub_1.dat_w), 0x12345678)
             self.assertEqual((yield sub_2.lock), 1)
-            self.assertEqual((yield sub_2.cti), CycleType.INCR_BURST.value)
-            self.assertEqual((yield sub_2.bte), BurstTypeExt.WRAP_4.value)
+            self.assertEqual((yield sub_2.cti), wishbone.CycleType.INCR_BURST.value)
+            self.assertEqual((yield sub_2.bte), wishbone.BurstTypeExt.WRAP_4.value)
             self.assertEqual((yield dut.bus.ack), 0)
             self.assertEqual((yield dut.bus.err), 1)
             self.assertEqual((yield dut.bus.rty), 1)
@@ -246,7 +307,7 @@ class DecoderSimulationTestCase(unittest.TestCase):
     def test_addr_translate(self):
         class AddressLoopback(Elaboratable):
             def __init__(self, **kwargs):
-                self.bus = Interface(**kwargs)
+                self.bus = wishbone.Signature(**kwargs).create()
 
             def elaborate(self, platform):
                 m = Module()
@@ -258,7 +319,7 @@ class DecoderSimulationTestCase(unittest.TestCase):
 
                 return m
 
-        dut = Decoder(addr_width=20, data_width=32, granularity=16)
+        dut = wishbone.Decoder(addr_width=20, data_width=32, granularity=16)
         loop_1 = AddressLoopback(addr_width=7, data_width=32, granularity=16)
         loop_1.bus.memory_map = MemoryMap(addr_width=8, data_width=16)
         self.assertEqual(dut.add(loop_1.bus, addr=0x10000),
@@ -355,8 +416,8 @@ class DecoderSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_coarse_granularity(self):
-        dut = Decoder(addr_width=3, data_width=32)
-        sub = Interface(addr_width=2, data_width=32)
+        dut = wishbone.Decoder(addr_width=3, data_width=32)
+        sub = wishbone.Signature(addr_width=2, data_width=32).create()
         sub.memory_map = MemoryMap(addr_width=2, data_width=32)
         dut.add(sub)
 
@@ -379,8 +440,8 @@ class DecoderSimulationTestCase(unittest.TestCase):
 
 class ArbiterTestCase(unittest.TestCase):
     def setUp(self):
-        self.dut = Arbiter(addr_width=31, data_width=32, granularity=16,
-                           features={"err"})
+        self.dut = wishbone.Arbiter(addr_width=31, data_width=32, granularity=16,
+                                    features={"err"})
 
     def test_add_wrong(self):
         with self.assertRaisesRegex(TypeError,
@@ -388,39 +449,48 @@ class ArbiterTestCase(unittest.TestCase):
             self.dut.add(intr_bus="foo")
 
     def test_add_wrong_addr_width(self):
+        intr = wishbone.Signature(addr_width=15, data_width=32, granularity=16,
+                                  features={"err"}).create()
         with self.assertRaisesRegex(ValueError,
                 r"Initiator bus has address width 15, which is not the same as arbiter "
                 r"address width 31"):
-            self.dut.add(Interface(addr_width=15, data_width=32, granularity=16))
+            self.dut.add(intr)
 
     def test_add_wrong_granularity(self):
+        intr = wishbone.Signature(addr_width=31, data_width=32, granularity=8,
+                                  features={"err"}).create()
         with self.assertRaisesRegex(ValueError,
                 r"Initiator bus has granularity 8, which is lesser than "
                 r"the arbiter granularity 16"):
-            self.dut.add(Interface(addr_width=31, data_width=32, granularity=8))
+            self.dut.add(intr)
 
     def test_add_wrong_data_width(self):
+        intr = wishbone.Signature(addr_width=31, data_width=16, granularity=16,
+                                  features={"err"}).create()
         with self.assertRaisesRegex(ValueError,
                 r"Initiator bus has data width 16, which is not the same as arbiter "
                 r"data width 32"):
-            self.dut.add(Interface(addr_width=31, data_width=16, granularity=16))
+            self.dut.add(intr)
 
     def test_add_wrong_optional_output(self):
+        intr = wishbone.Signature(addr_width=31, data_width=32, granularity=16).create()
         with self.assertRaisesRegex(ValueError,
                 r"Arbiter has optional output 'err', but the initiator bus does "
                 r"not have a corresponding input"):
-            self.dut.add(Interface(addr_width=31, data_width=32, granularity=16))
+            self.dut.add(intr)
 
 
 class ArbiterSimulationTestCase(unittest.TestCase):
     def test_simple(self):
-        dut = Arbiter(addr_width=30, data_width=32, granularity=8,
-                      features={"err", "rty", "stall", "lock", "cti", "bte"})
-        intr_1 = Interface(addr_width=30, data_width=32, granularity=8,
-                           features={"err", "rty"})
+        dut = wishbone.Arbiter(addr_width=30, data_width=32, granularity=8,
+                               features={"err", "rty", "stall", "lock", "cti", "bte"})
+
+        intr_1 = wishbone.Signature(addr_width=30, data_width=32, granularity=8,
+                                   features={"err", "rty"}).create()
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32, granularity=16,
-                      features={"err", "rty", "stall", "lock", "cti", "bte"})
+        intr_2 = wishbone.Signature(addr_width=30, data_width=32, granularity=16,
+                                    features={"err", "rty", "stall", "lock", "cti",
+                                              "bte"}).create()
         dut.add(intr_2)
 
         def sim_test():
@@ -442,8 +512,8 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             self.assertEqual((yield dut.bus.we), 1)
             self.assertEqual((yield dut.bus.dat_w), 0x12345678)
             self.assertEqual((yield dut.bus.lock), 0)
-            self.assertEqual((yield dut.bus.cti), CycleType.CLASSIC.value)
-            self.assertEqual((yield dut.bus.bte), BurstTypeExt.LINEAR.value)
+            self.assertEqual((yield dut.bus.cti), wishbone.CycleType.CLASSIC.value)
+            self.assertEqual((yield dut.bus.bte), wishbone.BurstTypeExt.LINEAR.value)
             self.assertEqual((yield intr_1.dat_r), 0xabcdef01)
             self.assertEqual((yield intr_1.ack), 1)
             self.assertEqual((yield intr_1.err), 1)
@@ -457,8 +527,8 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             yield intr_2.we.eq(1)
             yield intr_2.dat_w.eq(0x43218765)
             yield intr_2.lock.eq(0)
-            yield intr_2.cti.eq(CycleType.INCR_BURST)
-            yield intr_2.bte.eq(BurstTypeExt.WRAP_4)
+            yield intr_2.cti.eq(wishbone.CycleType.INCR_BURST)
+            yield intr_2.bte.eq(wishbone.BurstTypeExt.WRAP_4)
             yield Tick()
 
             yield dut.bus.stall.eq(0)
@@ -470,8 +540,8 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             self.assertEqual((yield dut.bus.we), 1)
             self.assertEqual((yield dut.bus.dat_w), 0x43218765)
             self.assertEqual((yield dut.bus.lock), 0)
-            self.assertEqual((yield dut.bus.cti), CycleType.INCR_BURST.value)
-            self.assertEqual((yield dut.bus.bte), BurstTypeExt.WRAP_4.value)
+            self.assertEqual((yield dut.bus.cti), wishbone.CycleType.INCR_BURST.value)
+            self.assertEqual((yield dut.bus.bte), wishbone.BurstTypeExt.WRAP_4.value)
             self.assertEqual((yield intr_2.dat_r), 0xabcdef01)
             self.assertEqual((yield intr_2.ack), 1)
             self.assertEqual((yield intr_2.err), 1)
@@ -485,10 +555,11 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_lock(self):
-        dut = Arbiter(addr_width=30, data_width=32, features={"lock"})
-        intr_1 = Interface(addr_width=30, data_width=32, features={"lock"})
+        dut = wishbone.Arbiter(addr_width=30, data_width=32, features={"lock"})
+        sig = wishbone.Signature(addr_width=30, data_width=32, features={"lock"})
+        intr_1 = wishbone.Interface(sig)
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32, features={"lock"})
+        intr_2 = wishbone.Interface(sig)
         dut.add(intr_2)
 
         def sim_test():
@@ -537,10 +608,11 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_stall(self):
-        dut = Arbiter(addr_width=30, data_width=32, features={"stall"})
-        intr_1 = Interface(addr_width=30, data_width=32, features={"stall"})
+        dut = wishbone.Arbiter(addr_width=30, data_width=32, features={"stall"})
+        sig = wishbone.Signature(addr_width=30, data_width=32, features={"stall"})
+        intr_1 = wishbone.Interface(sig)
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32, features={"stall"})
+        intr_2 = wishbone.Interface(sig)
         dut.add(intr_2)
 
         def sim_test():
@@ -562,10 +634,11 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_stall_compat(self):
-        dut = Arbiter(addr_width=30, data_width=32)
-        intr_1 = Interface(addr_width=30, data_width=32, features={"stall"})
+        dut = wishbone.Arbiter(addr_width=30, data_width=32)
+        sig = wishbone.Signature(addr_width=30, data_width=32, features={"stall"})
+        intr_1 = wishbone.Interface(sig)
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32, features={"stall"})
+        intr_2 = wishbone.Interface(sig)
         dut.add(intr_2)
 
         def sim_test():
@@ -586,12 +659,13 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_roundrobin(self):
-        dut = Arbiter(addr_width=30, data_width=32)
-        intr_1 = Interface(addr_width=30, data_width=32)
+        dut = wishbone.Arbiter(addr_width=30, data_width=32)
+        sig = wishbone.Signature(addr_width=30, data_width=32)
+        intr_1 = wishbone.Interface(sig)
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32)
+        intr_2 = wishbone.Interface(sig)
         dut.add(intr_2)
-        intr_3 = Interface(addr_width=30, data_width=32)
+        intr_3 = wishbone.Interface(sig)
         dut.add(intr_3)
 
         def sim_test():


### PR DESCRIPTION
Also, use Amaranth's `lib.enum` instead of standard enums.