### PR TITLE
Migrate bus primitives to `amaranth.lib.wiring`

### DIFF
--- a/amaranth_soc/csr/event.py
+++ b/amaranth_soc/csr/event.py
@@ -29,8 +29,10 @@ class EventMonitor(Elaboratable):
         CSR address alignment. See :class:`..memory.MemoryMap`.
     trigger : :class:`..event.Source.Trigger`
         Trigger mode. See :class:`..event.Source`.
+    name : str
+        Window name. Optional. See :class:`..memory.MemoryMap`.
     """
-    def __init__(self, *, data_width, alignment=0, trigger="level"):
+    def __init__(self, *, data_width, alignment=0, trigger="level", name=None):
         choices = ("level", "rise", "fall")
         if not isinstance(trigger, event.Source.Trigger) and trigger not in choices:
             raise ValueError("Invalid trigger mode {!r}; must be one of {}"
@@ -41,7 +43,8 @@ class EventMonitor(Elaboratable):
         self._monitor = None
         self._enable  = None
         self._pending = None
-        self._mux     = Multiplexer(addr_width=1, data_width=data_width, alignment=alignment)
+        self._mux     = Multiplexer(addr_width=1, data_width=data_width, alignment=alignment,
+                                    name=name)
         self._frozen  = False
 
     def freeze(self):
@@ -52,10 +55,10 @@ class EventMonitor(Elaboratable):
         if self._frozen:
             return
         self._monitor = event.Monitor(self._map, trigger=self._trigger)
-        self._enable  = Element(self._map.size, "rw")
-        self._pending = Element(self._map.size, "rw")
-        self._mux.add(self._enable,  extend=True)
-        self._mux.add(self._pending, extend=True)
+        self._enable  = Element(self._map.size, "rw", path=("enable",))
+        self._pending = Element(self._map.size, "rw", path=("pending",))
+        self._mux.add(self._enable,  name="enable",  extend=True)
+        self._mux.add(self._pending, name="pending", extend=True)
         self._frozen  = True
 
     @property

--- a/amaranth_soc/csr/wishbone.py
+++ b/amaranth_soc/csr/wishbone.py
@@ -2,7 +2,7 @@ from amaranth import *
 from amaranth.utils import log2_int
 
 from . import Interface as CSRInterface
-from ..wishbone import Interface as WishboneInterface
+from .. import wishbone
 from ..memory import MemoryMap
 
 
@@ -28,7 +28,7 @@ class WishboneCSRBridge(Elaboratable):
     data_width : int
         Wishbone bus data width. Optional. If ``None``, defaults to ``csr_bus.data_width``.
     name : str
-        Window name. Optional.
+        Window name. Optional. See :class:`..memory.MemoryMap`.
 
     Attributes
     ----------
@@ -46,11 +46,11 @@ class WishboneCSRBridge(Elaboratable):
             data_width = csr_bus.data_width
 
         self.csr_bus = csr_bus
-        self.wb_bus  = WishboneInterface(
+        self.wb_bus  = wishbone.Interface(
             addr_width=max(0, csr_bus.addr_width - log2_int(data_width // csr_bus.data_width)),
             data_width=data_width,
             granularity=csr_bus.data_width,
-            name="wb")
+            path=("wb",))
 
         wb_map = MemoryMap(addr_width=csr_bus.addr_width, data_width=csr_bus.data_width,
                            name=name)

--- a/amaranth_soc/wishbone/bus.py
+++ b/amaranth_soc/wishbone/bus.py
@@ -1,15 +1,15 @@
-from enum import Enum
 from amaranth import *
-from amaranth.hdl.rec import Direction
+from amaranth.lib import enum, wiring
+from amaranth.lib.wiring import In, Out
 from amaranth.utils import log2_int
 
 from ..memory import MemoryMap
 
 
-__all__ = ["CycleType", "BurstTypeExt", "Interface", "Decoder", "Arbiter"]
+__all__ = ["CycleType", "BurstTypeExt", "Feature", "Signature", "Interface", "Decoder", "Arbiter"]
 
 
-class CycleType(Enum):
+class CycleType(enum.Enum):
     """Wishbone Registered Feedback cycle type."""
     CLASSIC      = 0b000
     CONST_BURST  = 0b001
@@ -17,7 +17,7 @@ class CycleType(Enum):
     END_OF_BURST = 0b111
 
 
-class BurstTypeExt(Enum):
+class BurstTypeExt(enum.Enum):
     """Wishbone Registered Feedback burst type extension."""
     LINEAR  = 0b00
     WRAP_4  = 0b01
@@ -25,35 +25,22 @@ class BurstTypeExt(Enum):
     WRAP_16 = 0b11
 
 
-def _check_interface(addr_width, data_width, granularity, features):
-    if not isinstance(addr_width, int) or addr_width < 0:
-        raise ValueError("Address width must be a non-negative integer, not {!r}"
-                         .format(addr_width))
-    if data_width not in (8, 16, 32, 64):
-        raise ValueError("Data width must be one of 8, 16, 32, 64, not {!r}"
-                         .format(data_width))
-    if granularity not in (8, 16, 32, 64):
-        raise ValueError("Granularity must be one of 8, 16, 32, 64, not {!r}"
-                         .format(granularity))
-    if granularity > data_width:
-        raise ValueError("Granularity {} may not be greater than data width {}"
-                         .format(granularity, data_width))
-    unknown = set(features) - {"rty", "err", "stall", "lock", "cti", "bte"}
-    if unknown:
-        raise ValueError("Optional signal(s) {} are not supported"
-                         .format(", ".join(map(repr, unknown))))
+class Feature(enum.Enum):
+    """Optional Wishbone interface signals."""
+    ERR   = "err"
+    RTY   = "rty"
+    STALL = "stall"
+    LOCK  = "lock"
+    CTI   = "cti"
+    BTE   = "bte"
 
 
-class Interface(Record):
-    """Wishbone interface.
+class Signature(wiring.Signature):
+    """Wishbone interface signature.
 
     See the `Wishbone specification <https://opencores.org/howto/wishbone>`_ for description
     of the Wishbone signals. The ``RST_I`` and ``CLK_I`` signals are provided as a part of
     the clock domain that drives the interface.
-
-    Note that the data width of the underlying memory map of the interface is equal to port
-    granularity, not port size. If port granularity is less than port size, then the address width
-    of the underlying memory map is extended to reflect that.
 
     Parameters
     ----------
@@ -65,13 +52,11 @@ class Interface(Record):
     granularity : int
         Granularity of select signals ("port granularity" in Wishbone terminology).
         One of 8, 16, 32, 64.
-    features : iter(str)
+    features : iter(:class:`Feature`)
         Selects the optional signals that will be a part of this interface.
-    name : str
-        Name of the underlying record.
 
-    Attributes
-    ----------
+    Interface attributes
+    --------------------
     The correspondence between the Amaranth-SoC signals and the Wishbone signals changes depending
     on whether the interface acts as an initiator or a target.
 
@@ -99,74 +84,203 @@ class Interface(Record):
         Optional. Corresponds to Wishbone signal ``STALL_I`` (initiator) or ``STALL_O`` (target).
     lock : Signal()
         Optional. Corresponds to Wishbone signal ``LOCK_O`` (initiator) or ``LOCK_I`` (target).
-        amaranth-soc Wishbone support assumes that initiators that don't want bus arbitration to happen in
-        between two transactions need to use ``lock`` feature to guarantee this. An initiator without
-        the ``lock`` feature may be arbitrated in between two transactions even if ``cyc`` is kept high.
+        Amaranth-SoC Wishbone support assumes that initiators that don't want bus arbitration to
+        happen in between two transactions need to use ``lock`` feature to guarantee this. An
+        initiator without the ``lock`` feature may be arbitrated in between two transactions even
+        if ``cyc`` is kept high.
     cti : Signal()
         Optional. Corresponds to Wishbone signal ``CTI_O`` (initiator) or ``CTI_I`` (target).
     bte : Signal()
         Optional. Corresponds to Wishbone signal ``BTE_O`` (initiator) or ``BTE_I`` (target).
+
+    Raises
+    ------
+    See :meth:`Signature.check_parameters`.
     """
-    def __init__(self, *, addr_width, data_width, granularity=None, features=frozenset(),
-                 name=None):
+    def __init__(self, *, addr_width, data_width, granularity=None, features=frozenset()):
         if granularity is None:
             granularity  = data_width
-        _check_interface(addr_width, data_width, granularity, features)
+        self.check_parameters(addr_width=addr_width, data_width=data_width, granularity=granularity,
+                              features=features)
 
-        self.addr_width  = addr_width
-        self.data_width  = data_width
-        self.granularity = granularity
-        self._map        = None
+        self._addr_width  = addr_width
+        self._data_width  = data_width
+        self._granularity = granularity
+        self._features    = frozenset(Feature(f) for f in features)
 
-        features = set(features)
-        layout = [
-            ("adr",   addr_width, Direction.FANOUT),
-            ("dat_w", data_width, Direction.FANOUT),
-            ("dat_r", data_width, Direction.FANIN),
-            ("sel",   data_width // granularity, Direction.FANOUT),
-            ("cyc",   1, Direction.FANOUT),
-            ("stb",   1, Direction.FANOUT),
-            ("we",    1, Direction.FANOUT),
-            ("ack",   1, Direction.FANIN),
-        ]
-        if "err" in features:
-            layout += [("err", 1, Direction.FANIN)]
-        if "rty" in features:
-            layout += [("rty", 1, Direction.FANIN)]
-        if "stall" in features:
-            layout += [("stall", 1, Direction.FANIN)]
-        if "lock" in features:
-            layout += [("lock",  1, Direction.FANOUT)]
-        if "cti" in features:
-            layout += [("cti", CycleType,    Direction.FANOUT)]
-        if "bte" in features:
-            layout += [("bte", BurstTypeExt, Direction.FANOUT)]
-        super().__init__(layout, name=name, src_loc_at=1)
+        members = {
+            "adr":   Out(self.addr_width),
+            "dat_w": Out(self.data_width),
+            "dat_r": In(self.data_width),
+            "sel":   Out(self.data_width // self.granularity),
+            "cyc":   Out(1),
+            "stb":   Out(1),
+            "we":    Out(1),
+            "ack":   In(1),
+        }
+        if Feature.ERR in self.features:
+            members["err"]   = In(1)
+        if Feature.RTY in self.features:
+            members["rty"]   = In(1)
+        if Feature.STALL in self.features:
+            members["stall"] = In(1)
+        if Feature.LOCK in self.features:
+            members["lock"]  = Out(1)
+        if Feature.CTI in self.features:
+            members["cti"]   = Out(CycleType)
+        if Feature.BTE in self.features:
+            members["bte"]   = Out(BurstTypeExt)
+        super().__init__(members)
+
+    @property
+    def addr_width(self):
+        return self._addr_width
+
+    @property
+    def data_width(self):
+        return self._data_width
+
+    @property
+    def granularity(self):
+        return self._granularity
+
+    @property
+    def features(self):
+        return self._features
+
+    @classmethod
+    def check_parameters(cls, *, addr_width, data_width, granularity, features):
+        """Validate signature parameters.
+
+        Raises
+        ------
+        :exc:`TypeError`
+            If ``addr_width`` is not an integer greater than or equal to 0.
+        :exc:`ValueError`
+            If ``data_width`` is not 8, 16, 32 or 64.
+        :exc:`ValueError`
+            If ``granularity`` is not 8, 16, 32 or 64.
+        :exc:`ValueError`
+            If ``granularity`` is greater than ``data_width``.
+        :exc:`ValueError`
+            If ``features`` contains other values than :class:`Feature` members.
+        """
+        if not isinstance(addr_width, int) or addr_width < 0:
+            raise TypeError(f"Address width must be a non-negative integer, not {addr_width!r}")
+        if data_width not in (8, 16, 32, 64):
+            raise ValueError(f"Data width must be one of 8, 16, 32, 64, not {data_width!r}")
+        if granularity not in (8, 16, 32, 64):
+            raise ValueError(f"Granularity must be one of 8, 16, 32, 64, not {granularity!r}")
+        if granularity > data_width:
+            raise ValueError(f"Granularity {granularity} may not be greater than data width "
+                             f"{data_width}")
+        for feature in features:
+            Feature(feature) # raises ValueError if feature is invalid
+
+    def create(self, *, path=()):
+        """Create a compatible interface.
+
+        See :meth:`wiring.Signature.create` for details.
+
+        Returns
+        -------
+        An :class:`Interface` object using this signature.
+        """
+        return Interface(addr_width=self.addr_width, data_width=self.data_width,
+                         granularity=self.granularity, features=self.features, path=path)
+
+    def __eq__(self, other):
+        """Compare signatures.
+
+        Two signatures are equal if they have the same address width, data width, granularity and
+        features.
+        """
+        return (isinstance(other, Signature) and
+                self.addr_width == other.addr_width and
+                self.data_width == other.data_width and
+                self.granularity == other.granularity and
+                self.features == other.features)
+
+    def __repr__(self):
+        return f"wishbone.Signature({self.members!r})"
+
+
+class Interface(wiring.Interface):
+    """Wishbone bus interface.
+
+    Note that the data width of the underlying memory map of the interface is equal to port
+    granularity, not port size. If port granularity is less than port size, then the address width
+    of the underlying memory map is extended to reflect that.
+
+    Parameters
+    ----------
+    addr_width : :class:`int`
+        Width of the address signal. See :class:`Signature`.
+    data_width : :class:`int`
+        Width of the data signals. See :class:`Signature`.
+    granularity : :class:`int`
+        Granularity of select signals. See :class:`Signature`.
+    features : iter(:class:`Feature`)
+        Describes the optional signals of this interface. See :class:`Signature`.
+    path : iter(:class:`str`)
+        Path to this Wishbone interface. Optional. See :class:`wiring.Interface`.
+
+    Attributes
+    ----------
+    memory_map : :class:`MemoryMap`
+        Map of the bus.
+
+    Raises
+    ------
+    See :meth:`Signature.check_parameters`.
+    """
+    def __init__(self, *, addr_width, data_width, granularity=None, features=frozenset(), path=()):
+        super().__init__(Signature(addr_width=addr_width, data_width=data_width,
+                                   granularity=granularity, features=features), path=path)
+
+        self._map = None
+
+    @property
+    def addr_width(self):
+        return self.signature.addr_width
+
+    @property
+    def data_width(self):
+        return self.signature.data_width
+
+    @property
+    def granularity(self):
+        return self.signature.granularity
+
+    @property
+    def features(self):
+        return self.signature.features
 
     @property
     def memory_map(self):
         if self._map is None:
-            raise NotImplementedError("Bus interface {!r} does not have a memory map"
-                                      .format(self))
+            raise NotImplementedError(f"{self!r} does not have a memory map")
         return self._map
 
     @memory_map.setter
     def memory_map(self, memory_map):
         if not isinstance(memory_map, MemoryMap):
-            raise TypeError("Memory map must be an instance of MemoryMap, not {!r}"
-                            .format(memory_map))
+            raise TypeError(f"Memory map must be an instance of MemoryMap, not {memory_map!r}")
         if memory_map.data_width != self.granularity:
-            raise ValueError("Memory map has data width {}, which is not the same as bus "
-                             "interface granularity {}"
-                             .format(memory_map.data_width, self.granularity))
+            raise ValueError(f"Memory map has data width {memory_map.data_width}, which is not "
+                             f"the same as bus interface granularity {self.granularity}")
         granularity_bits = log2_int(self.data_width // self.granularity)
-        if memory_map.addr_width != max(1, self.addr_width + granularity_bits):
-            raise ValueError("Memory map has address width {}, which is not the same as bus "
-                             "interface address width {} ({} address bits + {} granularity bits)"
-                             .format(memory_map.addr_width, self.addr_width + granularity_bits,
-                                     self.addr_width, granularity_bits))
+        expected_addr_width = self.addr_width + granularity_bits
+        if memory_map.addr_width != max(1, expected_addr_width):
+            raise ValueError(f"Memory map has address width {memory_map.addr_width}, which is not "
+                             f"the same as bus interface address width {expected_addr_width} "
+                             f"({self.addr_width} address bits + {granularity_bits} granularity "
+                             f"bits)")
         memory_map.freeze()
         self._map = memory_map
+
+    def __repr__(self):
+        return f"wishbone.Interface({self.signature!r})"
 
 
 class Decoder(Elaboratable):
@@ -176,18 +290,18 @@ class Decoder(Elaboratable):
 
     Parameters
     ----------
-    addr_width : int
-        Address width. See :class:`Interface`.
-    data_width : int
-        Data width. See :class:`Interface`.
-    granularity : int
-        Granularity. See :class:`Interface`
-    features : iter(str)
-        Optional signal set. See :class:`Interface`.
+    addr_width : :class:`int`
+        Address width. See :class:`Signature`.
+    data_width : :class:`int`
+        Data width. See :class:`Signature`.
+    granularity : :class:`int`
+        Granularity. See :class:`Signature`
+    features : iter(:class:`Feature`)
+        Optional signal set. See :class:`Signature`.
     alignment : int, power-of-2 exponent
-        Window alignment. See :class:`..memory.MemoryMap`
-    name : str
-        Window name. Optional.
+        Window alignment. Optional. See :class:`..memory.MemoryMap`.
+    name : :class:`str`
+        Window name. Optional. See :class:`..memory.MemoryMap`.
 
     Attributes
     ----------
@@ -197,18 +311,16 @@ class Decoder(Elaboratable):
     def __init__(self, *, addr_width, data_width, granularity=None, features=frozenset(),
                  alignment=0, name=None):
         if granularity is None:
-            granularity  = data_width
-        _check_interface(addr_width, data_width, granularity, features)
+            granularity = data_width
+        Signature.check_parameters(addr_width=addr_width, data_width=data_width,
+                                   granularity=granularity, features=features)
 
         self.data_width  = data_width
         self.granularity = granularity
         self.features    = set(features)
         self.alignment   = alignment
-
-        granularity_bits = log2_int(data_width // granularity)
-        self._map        = MemoryMap(addr_width=max(1, addr_width + granularity_bits),
-                                     data_width=granularity, alignment=alignment,
-                                     name=name)
+        self._map        = MemoryMap(addr_width=max(1, addr_width + log2_int(data_width // granularity)),
+                                     data_width=granularity, alignment=alignment, name=name)
         self._subs       = dict()
         self._bus        = None
 
@@ -216,10 +328,10 @@ class Decoder(Elaboratable):
     def bus(self):
         if self._bus is None:
             self._map.freeze()
-            granularity_bits = log2_int(self.data_width // self.granularity)
-            self._bus = Interface(addr_width=self._map.addr_width - granularity_bits,
-                                  data_width=self.data_width, granularity=self.granularity,
-                                  features=self.features)
+            addr_width = self._map.addr_width - log2_int(self.data_width // self.granularity)
+            self._bus  = Interface(addr_width=addr_width, data_width=self.data_width,
+                                   granularity=self.granularity, features=self.features,
+                                   path=("bus",))
             self._bus.memory_map = self._map
         return self._bus
 
@@ -243,28 +355,25 @@ class Decoder(Elaboratable):
         See :meth:`MemoryMap.add_resource` for details.
         """
         if not isinstance(sub_bus, Interface):
-            raise TypeError("Subordinate bus must be an instance of wishbone.Interface, not {!r}"
-                            .format(sub_bus))
+            raise TypeError(f"Subordinate bus must be an instance of wishbone.Interface, not "
+                            f"{sub_bus!r}")
         if sub_bus.granularity > self.granularity:
-            raise ValueError("Subordinate bus has granularity {}, which is greater than the "
-                             "decoder granularity {}"
-                             .format(sub_bus.granularity, self.granularity))
+            raise ValueError(f"Subordinate bus has granularity {sub_bus.granularity}, which is "
+                             f"greater than the decoder granularity {self.granularity}")
         if not sparse:
             if sub_bus.data_width != self.data_width:
-                raise ValueError("Subordinate bus has data width {}, which is not the same as "
-                                 "decoder data width {} (required for dense address translation)"
-                                 .format(sub_bus.data_width, self.data_width))
+                raise ValueError(f"Subordinate bus has data width {sub_bus.data_width}, which is "
+                                 f"not the same as decoder data width {self.data_width} (required "
+                                 f"for dense address translation)")
         else:
             if sub_bus.granularity != sub_bus.data_width:
-                raise ValueError("Subordinate bus has data width {}, which is not the same as "
-                                 "subordinate bus granularity {} (required for sparse address "
-                                 "translation)"
-                                 .format(sub_bus.data_width, sub_bus.granularity))
+                raise ValueError(f"Subordinate bus has data width {sub_bus.data_width}, which is "
+                                 f"not the same as its granularity {sub_bus.granularity} "
+                                 f"(required for sparse address translation)")
         for opt_output in {"err", "rty", "stall"}:
             if hasattr(sub_bus, opt_output) and opt_output not in self.features:
-                raise ValueError("Subordinate bus has optional output {!r}, but the decoder "
-                                 "does not have a corresponding input"
-                                 .format(opt_output))
+                raise ValueError(f"Subordinate bus has optional output {opt_output!r}, but the "
+                                 f"decoder does not have a corresponding input")
 
         self._subs[sub_bus.memory_map] = sub_bus
         return self._map.add_window(sub_bus.memory_map, addr=addr, sparse=sparse, extend=extend)
@@ -328,13 +437,13 @@ class Arbiter(Elaboratable):
     Parameters
     ----------
     addr_width : int
-        Address width. See :class:`Interface`.
+        Address width. See :class:`Signature`.
     data_width : int
-        Data width. See :class:`Interface`.
+        Data width. See :class:`Signature`.
     granularity : int
-        Granularity. See :class:`Interface`
-    features : iter(str)
-        Optional signal set. See :class:`Interface`.
+        Granularity. See :class:`Signature`
+    features : iter(:class:`Feature`)
+        Optional signal set. See :class:`Signature`.
 
     Attributes
     ----------
@@ -342,9 +451,14 @@ class Arbiter(Elaboratable):
         Shared Wishbone bus.
     """
     def __init__(self, *, addr_width, data_width, granularity=None, features=frozenset()):
-        self.bus    = Interface(addr_width=addr_width, data_width=data_width,
-                                granularity=granularity, features=features)
+        self._bus   = Interface(addr_width=addr_width, data_width=data_width,
+                                granularity=granularity, features=features,
+                                path=("bus",))
         self._intrs = []
+
+    @property
+    def bus(self):
+        return self._bus
 
     def add(self, intr_bus):
         """Add an initiator bus to the arbiter.
@@ -354,25 +468,21 @@ class Arbiter(Elaboratable):
         the arbiter.
         """
         if not isinstance(intr_bus, Interface):
-            raise TypeError("Initiator bus must be an instance of wishbone.Interface, not {!r}"
-                            .format(intr_bus))
+            raise TypeError(f"Initiator bus must be an instance of wishbone.Interface, not "
+                            f"{intr_bus!r}")
         if intr_bus.addr_width != self.bus.addr_width:
-            raise ValueError("Initiator bus has address width {}, which is not the same as "
-                             "arbiter address width {}"
-                             .format(intr_bus.addr_width, self.bus.addr_width))
+            raise ValueError(f"Initiator bus has address width {intr_bus.addr_width}, which is "
+                             f"not the same as arbiter address width {self.bus.addr_width}")
         if intr_bus.granularity < self.bus.granularity:
-            raise ValueError("Initiator bus has granularity {}, which is lesser than the "
-                             "arbiter granularity {}"
-                             .format(intr_bus.granularity, self.bus.granularity))
+            raise ValueError(f"Initiator bus has granularity {intr_bus.granularity}, which is "
+                             f"lesser than the arbiter granularity {self.bus.granularity}")
         if intr_bus.data_width != self.bus.data_width:
-            raise ValueError("Initiator bus has data width {}, which is not the same as "
-                             "arbiter data width {}"
-                             .format(intr_bus.data_width, self.bus.data_width))
+            raise ValueError(f"Initiator bus has data width {intr_bus.data_width}, which is not "
+                             f"the same as arbiter data width {self.bus.data_width}")
         for opt_output in {"err", "rty"}:
             if hasattr(self.bus, opt_output) and not hasattr(intr_bus, opt_output):
-                raise ValueError("Arbiter has optional output {!r}, but the initiator bus "
-                                 "does not have a corresponding input"
-                                 .format(opt_output))
+                raise ValueError(f"Arbiter has optional output {opt_output!r}, but the initiator "
+                                 f"bus does not have a corresponding input")
 
         self._intrs.append(intr_bus)
 

--- a/tests/test_csr_event.py
+++ b/tests/test_csr_event.py
@@ -30,7 +30,7 @@ class EventMonitorTestCase(unittest.TestCase):
 
     def test_add(self):
         monitor = EventMonitor(data_width=8)
-        sub = event.Source()
+        sub = event.Source.Signature().create()
         monitor.add(sub)
         self.assertEqual(monitor.src.event_map.size, 1)
         self.assertEqual(monitor.src.event_map.index(sub), 0)
@@ -38,7 +38,7 @@ class EventMonitorTestCase(unittest.TestCase):
     def test_freeze(self):
         monitor = EventMonitor(data_width=8)
         monitor.freeze()
-        sub = event.Source()
+        sub = event.Source.Signature().create()
         with self.assertRaisesRegex(ValueError,
                 r"Event map has been frozen. Cannot add source."):
             monitor.add(sub)
@@ -46,7 +46,7 @@ class EventMonitorTestCase(unittest.TestCase):
     def test_src_freeze(self):
         monitor = EventMonitor(data_width=8)
         monitor.src
-        sub = event.Source()
+        sub = event.Source.Signature().create()
         with self.assertRaisesRegex(ValueError,
                 r"Event map has been frozen. Cannot add source."):
             monitor.add(sub)
@@ -54,15 +54,15 @@ class EventMonitorTestCase(unittest.TestCase):
     def test_bus_freeze(self):
         monitor = EventMonitor(data_width=8)
         monitor.bus
-        sub = event.Source()
+        sub = event.Source.Signature().create()
         with self.assertRaisesRegex(ValueError,
                 r"Event map has been frozen. Cannot add source."):
             monitor.add(sub)
 
     def test_csr_regs(self):
         monitor = EventMonitor(data_width=8)
-        sub_0 = event.Source()
-        sub_1 = event.Source()
+        sub_0 = event.Source.Signature().create()
+        sub_1 = event.Source.Signature().create()
         monitor.add(sub_0)
         monitor.add(sub_1)
         resources = list(monitor.bus.memory_map.resources())
@@ -90,7 +90,7 @@ class EventMonitorTestCase(unittest.TestCase):
 class EventMonitorSimulationTestCase(unittest.TestCase):
     def test_simple(self):
         dut = EventMonitor(data_width=8)
-        sub = event.Source()
+        sub = event.Source.Signature().create(path=("sub",))
         dut.add(sub)
 
         addr_enable  = 0x0

--- a/tests/test_periph.py
+++ b/tests/test_periph.py
@@ -115,7 +115,7 @@ class PeripheralInfoTestCase(unittest.TestCase):
 
     def test_irq(self):
         memory_map = MemoryMap(addr_width=1, data_width=8)
-        irq = event.Source()
+        irq = event.Source.Signature().create(path=("irq",))
         info = PeripheralInfo(memory_map=memory_map, irq=irq)
         self.assertIs(info.irq, irq)
 

--- a/tests/test_wishbone_bus.py
+++ b/tests/test_wishbone_bus.py
@@ -2,100 +2,169 @@
 
 import unittest
 from amaranth import *
-from amaranth.hdl.rec import *
+from amaranth.lib.wiring import *
 from amaranth.sim import *
 
-from amaranth_soc.wishbone.bus import *
+from amaranth_soc import wishbone
 from amaranth_soc.memory import MemoryMap
 
 
-class InterfaceTestCase(unittest.TestCase):
+class SignatureTestCase(unittest.TestCase):
     def test_simple(self):
-        iface = Interface(addr_width=32, data_width=8)
-        self.assertEqual(iface.addr_width, 32)
-        self.assertEqual(iface.data_width, 8)
-        self.assertEqual(iface.granularity, 8)
-        self.assertEqual(iface.layout, Layout.cast([
-            ("adr",   32, DIR_FANOUT),
-            ("dat_w", 8,  DIR_FANOUT),
-            ("dat_r", 8,  DIR_FANIN),
-            ("sel",   1,  DIR_FANOUT),
-            ("cyc",   1,  DIR_FANOUT),
-            ("stb",   1,  DIR_FANOUT),
-            ("we",    1,  DIR_FANOUT),
-            ("ack",   1,  DIR_FANIN),
-        ]))
+        sig = wishbone.Signature(addr_width=32, data_width=8)
+        self.assertEqual(sig.addr_width, 32)
+        self.assertEqual(sig.data_width,  8)
+        self.assertEqual(sig.granularity, 8)
+        self.assertEqual(sig.members, Signature({
+            "adr":   Out(32),
+            "dat_w": Out(8),
+            "dat_r": In(8),
+            "sel":   Out(1),
+            "cyc":   Out(1),
+            "stb":   Out(1),
+            "we":    Out(1),
+            "ack":   In(1),
+        }).members)
 
     def test_granularity(self):
-        iface = Interface(addr_width=30, data_width=32, granularity=8)
-        self.assertEqual(iface.addr_width, 30)
-        self.assertEqual(iface.data_width, 32)
-        self.assertEqual(iface.granularity, 8)
-        self.assertEqual(iface.layout, Layout.cast([
-            ("adr",   30, DIR_FANOUT),
-            ("dat_w", 32, DIR_FANOUT),
-            ("dat_r", 32, DIR_FANIN),
-            ("sel",   4,  DIR_FANOUT),
-            ("cyc",   1,  DIR_FANOUT),
-            ("stb",   1,  DIR_FANOUT),
-            ("we",    1,  DIR_FANOUT),
-            ("ack",   1,  DIR_FANIN),
-        ]))
+        sig = wishbone.Signature(addr_width=30, data_width=32, granularity=8)
+        self.assertEqual(sig.addr_width, 30)
+        self.assertEqual(sig.data_width, 32)
+        self.assertEqual(sig.granularity, 8)
+        self.assertEqual(sig.members, Signature({
+            "adr":   Out(30),
+            "dat_w": Out(32),
+            "dat_r": In(32),
+            "sel":   Out(4),
+            "cyc":   Out(1),
+            "stb":   Out(1),
+            "we":    Out(1),
+            "ack":   In(1),
+        }).members)
 
     def test_features(self):
-        iface = Interface(addr_width=32, data_width=32,
-                          features={"rty", "err", "stall", "lock", "cti", "bte"})
-        self.assertEqual(iface.layout, Layout.cast([
-            ("adr",   32, DIR_FANOUT),
-            ("dat_w", 32, DIR_FANOUT),
-            ("dat_r", 32, DIR_FANIN),
-            ("sel",   1,  DIR_FANOUT),
-            ("cyc",   1,  DIR_FANOUT),
-            ("stb",   1,  DIR_FANOUT),
-            ("we",    1,  DIR_FANOUT),
-            ("ack",   1,  DIR_FANIN),
-            ("err",   1,  DIR_FANIN),
-            ("rty",   1,  DIR_FANIN),
-            ("stall", 1,  DIR_FANIN),
-            ("lock",  1,  DIR_FANOUT),
-            ("cti",   CycleType,    DIR_FANOUT),
-            ("bte",   BurstTypeExt, DIR_FANOUT),
-        ]))
+        sig = wishbone.Signature(addr_width=32, data_width=32,
+                                 features={"rty", "err", "stall", "lock", "cti", "bte"})
+        self.assertEqual(sig.features, {
+            wishbone.Feature.RTY,
+            wishbone.Feature.ERR,
+            wishbone.Feature.STALL,
+            wishbone.Feature.LOCK,
+            wishbone.Feature.CTI,
+            wishbone.Feature.BTE,
+        })
+        self.assertEqual(sig.members, Signature({
+            "adr":   Out(32),
+            "dat_w": Out(32),
+            "dat_r": In(32),
+            "sel":   Out(1),
+            "cyc":   Out(1),
+            "stb":   Out(1),
+            "we":    Out(1),
+            "ack":   In(1),
+            "err":   In(1),
+            "rty":   In(1),
+            "stall": In(1),
+            "lock":  Out(1),
+            "cti":   Out(wishbone.CycleType),
+            "bte":   Out(wishbone.BurstTypeExt),
+        }).members)
+
+    def test_create(self):
+        sig   = wishbone.Signature(addr_width=32, data_width=16, granularity=8)
+        iface = sig.create(path=("foo", "bar"))
+        self.assertIsInstance(iface, wishbone.Interface)
+        self.assertEqual(iface.addr_width, 32)
+        self.assertEqual(iface.data_width, 16)
+        self.assertEqual(iface.granularity, 8)
+        self.assertEqual(iface.cyc.name, "foo__bar__cyc")
+        self.assertEqual(iface.signature, sig)
+
+    def test_eq(self):
+        self.assertEqual(wishbone.Signature(addr_width=32, data_width=8, features={"err"}),
+                         wishbone.Signature(addr_width=32, data_width=8, features={"err"}))
+        # different addr_width
+        self.assertNotEqual(wishbone.Signature(addr_width=16, data_width=16, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=8))
+        # different data_width
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=8, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=8))
+        # different granularity
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=16, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=16))
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=16, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16))
+        # different features
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=16, granularity=8),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=8,
+                                               features={"err"}))
+        self.assertNotEqual(wishbone.Signature(addr_width=32, data_width=16, granularity=8,
+                                               features={"rty"}),
+                            wishbone.Signature(addr_width=32, data_width=16, granularity=8,
+                                               features={"err"}))
 
     def test_wrong_addr_width(self):
-        with self.assertRaisesRegex(ValueError,
+        with self.assertRaisesRegex(TypeError,
                 r"Address width must be a non-negative integer, not -1"):
-            Interface(addr_width=-1, data_width=8)
+            wishbone.Signature(addr_width=-1, data_width=8)
+        with self.assertRaisesRegex(TypeError,
+                r"Address width must be a non-negative integer, not -1"):
+            wishbone.Signature.check_parameters(addr_width=-1, data_width=8, granularity=8,
+                                                features=())
 
     def test_wrong_data_width(self):
         with self.assertRaisesRegex(ValueError,
                 r"Data width must be one of 8, 16, 32, 64, not 7"):
-            Interface(addr_width=0, data_width=7)
+            wishbone.Signature(addr_width=0, data_width=7)
+        with self.assertRaisesRegex(ValueError,
+                r"Data width must be one of 8, 16, 32, 64, not 7"):
+            wishbone.Signature.check_parameters(addr_width=0, data_width=7, granularity=7,
+                                                features=())
 
     def test_wrong_granularity(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity must be one of 8, 16, 32, 64, not 7"):
-            Interface(addr_width=0, data_width=32, granularity=7)
+            wishbone.Signature(addr_width=0, data_width=32, granularity=7)
+        with self.assertRaisesRegex(ValueError,
+                r"Granularity must be one of 8, 16, 32, 64, not 7"):
+            wishbone.Signature.check_parameters(addr_width=0, data_width=32, granularity=7,
+                                                features=())
 
     def test_wrong_granularity_wide(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity 32 may not be greater than data width 8"):
-            Interface(addr_width=0, data_width=8, granularity=32)
+            wishbone.Signature(addr_width=0, data_width=8, granularity=32)
+        with self.assertRaisesRegex(ValueError,
+                r"Granularity 32 may not be greater than data width 8"):
+            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=32,
+                                                features=())
 
     def test_wrong_features(self):
-        with self.assertRaisesRegex(ValueError,
-                r"Optional signal\(s\) 'foo' are not supported"):
-            Interface(addr_width=0, data_width=8, features={"foo"})
+        with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
+            wishbone.Signature(addr_width=0, data_width=8, features={"foo"})
+        with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
+            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=8,
+                                                features={"foo"})
+
+
+class InterfaceTestCase(unittest.TestCase):
+    def test_simple(self):
+        iface = wishbone.Interface(addr_width=32, data_width=8, features={"err"},
+                                   path=("foo", "bar"))
+        self.assertEqual(iface.addr_width, 32)
+        self.assertEqual(iface.data_width, 8)
+        self.assertEqual(iface.granularity, 8)
+        self.assertEqual(iface.features, {wishbone.Feature.ERR})
+        self.assertEqual(iface.cyc.name, "foo__bar__cyc")
 
     def test_get_map_wrong(self):
-        iface = Interface(addr_width=0, data_width=8)
+        iface = wishbone.Interface(addr_width=0, data_width=8, path=("iface",))
         with self.assertRaisesRegex(NotImplementedError,
-                r"Bus interface \(rec iface adr dat_w dat_r sel cyc stb we ack\) does "
-                r"not have a memory map"):
+                r"wishbone.Interface\(.*\) does not have a memory map"):
             iface.memory_map
 
     def test_get_map_frozen(self):
-        iface = Interface(addr_width=1, data_width=8)
+        iface = wishbone.Interface(addr_width=1, data_width=8, path=("iface",))
         iface.memory_map = MemoryMap(addr_width=1, data_width=8)
         with self.assertRaisesRegex(ValueError,
                 r"Memory map has been frozen\. Address width cannot be extended "
@@ -103,20 +172,20 @@ class InterfaceTestCase(unittest.TestCase):
             iface.memory_map.addr_width = 2
 
     def test_set_map_wrong(self):
-        iface = Interface(addr_width=0, data_width=8)
+        iface = wishbone.Interface(addr_width=0, data_width=8, path=("iface",))
         with self.assertRaisesRegex(TypeError,
                 r"Memory map must be an instance of MemoryMap, not 'foo'"):
             iface.memory_map = "foo"
 
     def test_set_map_wrong_data_width(self):
-        iface = Interface(addr_width=30, data_width=32, granularity=8)
+        iface = wishbone.Interface(addr_width=30, data_width=32, granularity=8, path=("iface",))
         with self.assertRaisesRegex(ValueError,
                 r"Memory map has data width 32, which is not the same as bus "
                 r"interface granularity 8"):
             iface.memory_map = MemoryMap(addr_width=32, data_width=32)
 
     def test_set_map_wrong_addr_width(self):
-        iface = Interface(addr_width=30, data_width=32, granularity=8)
+        iface = wishbone.Interface(addr_width=30, data_width=32, granularity=8, path=("iface",))
         with self.assertRaisesRegex(ValueError,
                 r"Memory map has address width 30, which is not the same as bus "
                 r"interface address width 32 \(30 address bits \+ 2 granularity bits\)"):
@@ -125,12 +194,13 @@ class InterfaceTestCase(unittest.TestCase):
 
 class DecoderTestCase(unittest.TestCase):
     def setUp(self):
-        self.dut = Decoder(addr_width=31, data_width=32, granularity=16)
+        self.dut = wishbone.Decoder(addr_width=31, data_width=32, granularity=16)
 
     def test_add_align_to(self):
-        sub_1 = Interface(addr_width=15, data_width=32, granularity=16)
+        sig   = wishbone.Signature(addr_width=15, data_width=32, granularity=16)
+        sub_1 = sig.create(path=("sub_1"))
+        sub_2 = sig.create(path=("sub_2"))
         sub_1.memory_map = MemoryMap(addr_width=16, data_width=16)
-        sub_2 = Interface(addr_width=15, data_width=32, granularity=16)
         sub_2.memory_map = MemoryMap(addr_width=16, data_width=16)
         self.assertEqual(self.dut.add(sub_1), (0x00000000, 0x00010000, 1))
         self.assertEqual(self.dut.align_to(18), 0x000040000)
@@ -138,7 +208,7 @@ class DecoderTestCase(unittest.TestCase):
         self.assertEqual(self.dut.add(sub_2), (0x00040000, 0x00050000, 1))
 
     def test_add_extend(self):
-        sub = Interface(addr_width=31, data_width=32, granularity=16)
+        sub = wishbone.Interface(addr_width=31, data_width=32, granularity=16, path=("sub",))
         sub.memory_map = MemoryMap(addr_width=32, data_width=16)
         self.assertEqual(self.dut.add(sub, addr=1, extend=True), (1, 0x100000001, 1))
         self.assertEqual(self.dut.bus.addr_width, 32)
@@ -149,31 +219,36 @@ class DecoderTestCase(unittest.TestCase):
             self.dut.add(sub_bus="foo")
 
     def test_add_wrong_granularity(self):
+        sub = wishbone.Interface(addr_width=15, data_width=32, granularity=32, path=("sub",))
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has granularity 32, which is greater than "
                 r"the decoder granularity 16"):
-            self.dut.add(Interface(addr_width=15, data_width=32, granularity=32))
+            self.dut.add(sub)
 
     def test_add_wrong_width_dense(self):
+        sub = wishbone.Interface(addr_width=15, data_width=16, granularity=16, path=("sub",))
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has data width 16, which is not the same as decoder "
                 r"data width 32 \(required for dense address translation\)"):
-            self.dut.add(Interface(addr_width=15, data_width=16, granularity=16))
+            self.dut.add(sub)
 
     def test_add_wrong_granularity_sparse(self):
+        sub = wishbone.Interface(addr_width=15, data_width=64, granularity=16, path=("sub",))
         with self.assertRaisesRegex(ValueError,
-                r"Subordinate bus has data width 64, which is not the same as subordinate "
-                r"bus granularity 16 \(required for sparse address translation\)"):
-            self.dut.add(Interface(addr_width=15, data_width=64, granularity=16), sparse=True)
+                r"Subordinate bus has data width 64, which is not the same as its "
+                r"granularity 16 \(required for sparse address translation\)"):
+            self.dut.add(sub, sparse=True)
 
     def test_add_wrong_optional_output(self):
+        sub = wishbone.Interface(addr_width=15, data_width=32, granularity=16, features={"err"},
+                                 path=("sub",))
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has optional output 'err', but the decoder does "
                 r"not have a corresponding input"):
-            self.dut.add(Interface(addr_width=15, data_width=32, granularity=16, features={"err"}))
+            self.dut.add(sub)
 
     def test_add_wrong_out_of_bounds(self):
-        sub = Interface(addr_width=31, data_width=32, granularity=16)
+        sub = wishbone.Interface(addr_width=31, data_width=32, granularity=16, path=("sub",))
         sub.memory_map = MemoryMap(addr_width=32, data_width=16)
         with self.assertRaisesRegex(ValueError,
             r"Address range 0x1\.\.0x100000001 out of bounds for memory map spanning "
@@ -183,13 +258,14 @@ class DecoderTestCase(unittest.TestCase):
 
 class DecoderSimulationTestCase(unittest.TestCase):
     def test_simple(self):
-        dut = Decoder(addr_width=30, data_width=32, granularity=8,
-                      features={"err", "rty", "stall", "lock", "cti", "bte"})
-        sub_1 = Interface(addr_width=14, data_width=32, granularity=8)
+        dut = wishbone.Decoder(addr_width=30, data_width=32, granularity=8,
+                               features={"err", "rty", "stall", "lock", "cti", "bte"})
+        sub_1 = wishbone.Interface(addr_width=14, data_width=32, granularity=8, path=("sub_1",))
         sub_1.memory_map = MemoryMap(addr_width=16, data_width=8)
         dut.add(sub_1, addr=0x10000)
-        sub_2 = Interface(addr_width=14, data_width=32, granularity=8,
-                          features={"err", "rty", "stall", "lock", "cti", "bte"})
+        sub_2 = wishbone.Interface(addr_width=14, data_width=32, granularity=8,
+                                   features={"err", "rty", "stall", "lock", "cti", "bte"},
+                                   path=("sub_2",))
         sub_2.memory_map = MemoryMap(addr_width=16, data_width=8)
         dut.add(sub_2)
 
@@ -200,8 +276,8 @@ class DecoderSimulationTestCase(unittest.TestCase):
             yield dut.bus.sel.eq(0b11)
             yield dut.bus.dat_w.eq(0x12345678)
             yield dut.bus.lock.eq(1)
-            yield dut.bus.cti.eq(CycleType.INCR_BURST)
-            yield dut.bus.bte.eq(BurstTypeExt.WRAP_4)
+            yield dut.bus.cti.eq(wishbone.CycleType.INCR_BURST)
+            yield dut.bus.bte.eq(wishbone.BurstTypeExt.WRAP_4)
             yield sub_1.ack.eq(1)
             yield sub_1.dat_r.eq(0xabcdef01)
             yield sub_2.dat_r.eq(0x5678abcd)
@@ -230,8 +306,8 @@ class DecoderSimulationTestCase(unittest.TestCase):
             self.assertEqual((yield sub_1.sel), 0b11)
             self.assertEqual((yield sub_1.dat_w), 0x12345678)
             self.assertEqual((yield sub_2.lock), 1)
-            self.assertEqual((yield sub_2.cti), CycleType.INCR_BURST.value)
-            self.assertEqual((yield sub_2.bte), BurstTypeExt.WRAP_4.value)
+            self.assertEqual((yield sub_2.cti), wishbone.CycleType.INCR_BURST.value)
+            self.assertEqual((yield sub_2.bte), wishbone.BurstTypeExt.WRAP_4.value)
             self.assertEqual((yield dut.bus.ack), 0)
             self.assertEqual((yield dut.bus.err), 1)
             self.assertEqual((yield dut.bus.rty), 1)
@@ -246,7 +322,7 @@ class DecoderSimulationTestCase(unittest.TestCase):
     def test_addr_translate(self):
         class AddressLoopback(Elaboratable):
             def __init__(self, **kwargs):
-                self.bus = Interface(**kwargs)
+                self.bus = wishbone.Signature(**kwargs).create()
 
             def elaborate(self, platform):
                 m = Module()
@@ -258,7 +334,7 @@ class DecoderSimulationTestCase(unittest.TestCase):
 
                 return m
 
-        dut = Decoder(addr_width=20, data_width=32, granularity=16)
+        dut = wishbone.Decoder(addr_width=20, data_width=32, granularity=16)
         loop_1 = AddressLoopback(addr_width=7, data_width=32, granularity=16)
         loop_1.bus.memory_map = MemoryMap(addr_width=8, data_width=16)
         self.assertEqual(dut.add(loop_1.bus, addr=0x10000),
@@ -355,8 +431,8 @@ class DecoderSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_coarse_granularity(self):
-        dut = Decoder(addr_width=3, data_width=32)
-        sub = Interface(addr_width=2, data_width=32)
+        dut = wishbone.Decoder(addr_width=3, data_width=32)
+        sub = wishbone.Interface(addr_width=2, data_width=32, path=("sub",))
         sub.memory_map = MemoryMap(addr_width=2, data_width=32)
         dut.add(sub)
 
@@ -379,8 +455,8 @@ class DecoderSimulationTestCase(unittest.TestCase):
 
 class ArbiterTestCase(unittest.TestCase):
     def setUp(self):
-        self.dut = Arbiter(addr_width=31, data_width=32, granularity=16,
-                           features={"err"})
+        self.dut = wishbone.Arbiter(addr_width=31, data_width=32, granularity=16,
+                                    features={"err"})
 
     def test_add_wrong(self):
         with self.assertRaisesRegex(TypeError,
@@ -388,39 +464,49 @@ class ArbiterTestCase(unittest.TestCase):
             self.dut.add(intr_bus="foo")
 
     def test_add_wrong_addr_width(self):
+        intr = wishbone.Interface(addr_width=15, data_width=32, granularity=16,
+                                  features={"err"}, path=("intr",))
         with self.assertRaisesRegex(ValueError,
                 r"Initiator bus has address width 15, which is not the same as arbiter "
                 r"address width 31"):
-            self.dut.add(Interface(addr_width=15, data_width=32, granularity=16))
+            self.dut.add(intr)
 
     def test_add_wrong_granularity(self):
+        intr = wishbone.Interface(addr_width=31, data_width=32, granularity=8,
+                                  features={"err"}, path=("intr",))
         with self.assertRaisesRegex(ValueError,
                 r"Initiator bus has granularity 8, which is lesser than "
                 r"the arbiter granularity 16"):
-            self.dut.add(Interface(addr_width=31, data_width=32, granularity=8))
+            self.dut.add(intr)
 
     def test_add_wrong_data_width(self):
+        intr = wishbone.Interface(addr_width=31, data_width=16, granularity=16,
+                                  features={"err"}, path=("intr",))
         with self.assertRaisesRegex(ValueError,
                 r"Initiator bus has data width 16, which is not the same as arbiter "
                 r"data width 32"):
-            self.dut.add(Interface(addr_width=31, data_width=16, granularity=16))
+            self.dut.add(intr)
 
     def test_add_wrong_optional_output(self):
+        intr = wishbone.Interface(addr_width=31, data_width=32, granularity=16, path=("intr",))
         with self.assertRaisesRegex(ValueError,
                 r"Arbiter has optional output 'err', but the initiator bus does "
                 r"not have a corresponding input"):
-            self.dut.add(Interface(addr_width=31, data_width=32, granularity=16))
+            self.dut.add(intr)
 
 
 class ArbiterSimulationTestCase(unittest.TestCase):
     def test_simple(self):
-        dut = Arbiter(addr_width=30, data_width=32, granularity=8,
-                      features={"err", "rty", "stall", "lock", "cti", "bte"})
-        intr_1 = Interface(addr_width=30, data_width=32, granularity=8,
-                           features={"err", "rty"})
+        dut = wishbone.Arbiter(addr_width=30, data_width=32, granularity=8,
+                               features={"err", "rty", "stall", "lock", "cti", "bte"})
+
+        intr_1 = wishbone.Interface(addr_width=30, data_width=32, granularity=8,
+                                    features={"err", "rty"}, path=("intr_1",))
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32, granularity=16,
-                      features={"err", "rty", "stall", "lock", "cti", "bte"})
+        intr_2 = wishbone.Interface(addr_width=30, data_width=32, granularity=16,
+                                    features={"err", "rty", "stall", "lock", "cti",
+                                              "bte"},
+                                    path=("intr_2",))
         dut.add(intr_2)
 
         def sim_test():
@@ -442,8 +528,8 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             self.assertEqual((yield dut.bus.we), 1)
             self.assertEqual((yield dut.bus.dat_w), 0x12345678)
             self.assertEqual((yield dut.bus.lock), 0)
-            self.assertEqual((yield dut.bus.cti), CycleType.CLASSIC.value)
-            self.assertEqual((yield dut.bus.bte), BurstTypeExt.LINEAR.value)
+            self.assertEqual((yield dut.bus.cti), wishbone.CycleType.CLASSIC.value)
+            self.assertEqual((yield dut.bus.bte), wishbone.BurstTypeExt.LINEAR.value)
             self.assertEqual((yield intr_1.dat_r), 0xabcdef01)
             self.assertEqual((yield intr_1.ack), 1)
             self.assertEqual((yield intr_1.err), 1)
@@ -457,8 +543,8 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             yield intr_2.we.eq(1)
             yield intr_2.dat_w.eq(0x43218765)
             yield intr_2.lock.eq(0)
-            yield intr_2.cti.eq(CycleType.INCR_BURST)
-            yield intr_2.bte.eq(BurstTypeExt.WRAP_4)
+            yield intr_2.cti.eq(wishbone.CycleType.INCR_BURST)
+            yield intr_2.bte.eq(wishbone.BurstTypeExt.WRAP_4)
             yield Tick()
 
             yield dut.bus.stall.eq(0)
@@ -470,8 +556,8 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             self.assertEqual((yield dut.bus.we), 1)
             self.assertEqual((yield dut.bus.dat_w), 0x43218765)
             self.assertEqual((yield dut.bus.lock), 0)
-            self.assertEqual((yield dut.bus.cti), CycleType.INCR_BURST.value)
-            self.assertEqual((yield dut.bus.bte), BurstTypeExt.WRAP_4.value)
+            self.assertEqual((yield dut.bus.cti), wishbone.CycleType.INCR_BURST.value)
+            self.assertEqual((yield dut.bus.bte), wishbone.BurstTypeExt.WRAP_4.value)
             self.assertEqual((yield intr_2.dat_r), 0xabcdef01)
             self.assertEqual((yield intr_2.ack), 1)
             self.assertEqual((yield intr_2.err), 1)
@@ -485,10 +571,11 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_lock(self):
-        dut = Arbiter(addr_width=30, data_width=32, features={"lock"})
-        intr_1 = Interface(addr_width=30, data_width=32, features={"lock"})
+        dut = wishbone.Arbiter(addr_width=30, data_width=32, features={"lock"})
+        sig = wishbone.Signature(addr_width=30, data_width=32, features={"lock"})
+        intr_1 = sig.create(path=("intr_1",))
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32, features={"lock"})
+        intr_2 = sig.create(path=("intr_2",))
         dut.add(intr_2)
 
         def sim_test():
@@ -537,10 +624,11 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_stall(self):
-        dut = Arbiter(addr_width=30, data_width=32, features={"stall"})
-        intr_1 = Interface(addr_width=30, data_width=32, features={"stall"})
+        dut = wishbone.Arbiter(addr_width=30, data_width=32, features={"stall"})
+        sig = wishbone.Signature(addr_width=30, data_width=32, features={"stall"})
+        intr_1 = sig.create(path=("intr_1",))
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32, features={"stall"})
+        intr_2 = sig.create(path=("intr_2",))
         dut.add(intr_2)
 
         def sim_test():
@@ -562,10 +650,11 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_stall_compat(self):
-        dut = Arbiter(addr_width=30, data_width=32)
-        intr_1 = Interface(addr_width=30, data_width=32, features={"stall"})
+        dut = wishbone.Arbiter(addr_width=30, data_width=32)
+        sig = wishbone.Signature(addr_width=30, data_width=32, features={"stall"})
+        intr_1 = sig.create(path=("intr_1",))
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32, features={"stall"})
+        intr_2 = sig.create(path=("intr_2",))
         dut.add(intr_2)
 
         def sim_test():
@@ -586,12 +675,13 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             sim.run()
 
     def test_roundrobin(self):
-        dut = Arbiter(addr_width=30, data_width=32)
-        intr_1 = Interface(addr_width=30, data_width=32)
+        dut = wishbone.Arbiter(addr_width=30, data_width=32)
+        sig = wishbone.Signature(addr_width=30, data_width=32)
+        intr_1 = sig.create(path=("intr_1",))
         dut.add(intr_1)
-        intr_2 = Interface(addr_width=30, data_width=32)
+        intr_2 = sig.create(path=("intr_2",))
         dut.add(intr_2)
-        intr_3 = Interface(addr_width=30, data_width=32)
+        intr_3 = sig.create(path=("intr_3",))
         dut.add(intr_3)
 
         def sim_test():


### PR DESCRIPTION
Supersedes #48, as the changes to CSR and Wishbone are similar in nature, and would benefit from a common review.