### PR TITLE
Minor docstring clarifications.

### DIFF
--- a/amaranth_soc/csr/bus.py
+++ b/amaranth_soc/csr/bus.py
@@ -383,7 +383,7 @@ class Multiplexer(Elaboratable):
         Address width. See :class:`Interface`.
     data_width : int
         Data width. See :class:`Interface`.
-    alignment : log2 of int
+    alignment : int, power-of-2 exponent
         Register alignment. See :class:`..memory.MemoryMap`.
     name : str
         Window name. Optional.
@@ -534,7 +534,7 @@ class Decoder(Elaboratable):
         Address width. See :class:`Interface`.
     data_width : int
         Data width. See :class:`Interface`.
-    alignment : log2 of int
+    alignment : int, power-of-2 exponent
         Window alignment. See :class:`..memory.MemoryMap`.
     name : str
         Window name. Optional.

--- a/amaranth_soc/csr/event.py
+++ b/amaranth_soc/csr/event.py
@@ -25,7 +25,7 @@ class EventMonitor(Elaboratable):
     ----------
     data_width : int
         CSR bus data width. See :class:`..csr.Interface`.
-    alignment : int
+    alignment : int, power-of-2 exponent
         CSR address alignment. See :class:`..memory.MemoryMap`.
     trigger : :class:`..event.Source.Trigger`
         Trigger mode. See :class:`..event.Source`.

--- a/amaranth_soc/csr/wishbone.py
+++ b/amaranth_soc/csr/wishbone.py
@@ -25,8 +25,8 @@ class WishboneCSRBridge(Elaboratable):
     ----------
     csr_bus : :class:`..csr.Interface`
         CSR bus driven by the bridge.
-    data_width : int or None
-        Wishbone bus data width. If not specified, defaults to ``csr_bus.data_width``.
+    data_width : int
+        Wishbone bus data width. Optional. If ``None``, defaults to ``csr_bus.data_width``.
     name : str
         Window name. Optional.
 

--- a/amaranth_soc/memory.py
+++ b/amaranth_soc/memory.py
@@ -135,7 +135,7 @@ class MemoryMap:
         Address width.
     data_width : int
         Data width.
-    alignment : log2 of int
+    alignment : int, power-of-2 exponent
         Range alignment. Each added resource and window will be placed at an address that is
         a multiple of ``2 ** alignment``, and its size will be rounded up to be a multiple of
         ``2 ** alignment``.
@@ -217,7 +217,7 @@ class MemoryMap:
 
         Arguments
         ---------
-        alignment : log2 of int
+        alignment : int, power-of-2 exponent
             Address alignment. The start of the implicit next address will be a multiple of
             ``2 ** max(alignment, self.alignment)``.
 
@@ -287,15 +287,15 @@ class MemoryMap:
         name : str
             Name of the resource. It must not collide with the name of other resources or windows
             present in this memory map.
-        addr : int or None
-            Address of the resource. If ``None``, the implicit next address will be used.
+        addr : int
+            Address of the resource. Optional. If ``None``, the implicit next address will be used.
             Otherwise, the exact specified address (which must be a multiple of
             ``2 ** max(alignment, self.alignment)``) will be used.
         size : int
             Size of the resource, in minimal addressable units. Rounded up to a multiple of
             ``2 ** max(alignment, self.alignment)``.
-        alignment : log2 of int or None
-            Alignment of the resource. If not specified, the memory map alignment is used.
+        alignment : int, power-of-2 exponent
+            Alignment of the resource. Optional. If ``None``, the memory map alignment is used.
         extend: bool
             Allow memory map extension. If ``True``, the upper bound of the address space is
             raised as needed, in order to fit a resource that would otherwise be out of bounds.
@@ -379,13 +379,13 @@ class MemoryMap:
         window : :class:`MemoryMap`
             A memory map describing the layout of the window. It is frozen as a side-effect of
             being added to this memory map.
-        addr : int or None
-            Address of the window. If ``None``, the implicit next address will be used after
-            aligning it to ``2 ** window.addr_width``. Otherwise, the exact specified address
+        addr : int
+            Address of the window. Optional. If ``None``, the implicit next address will be used
+            after aligning it to ``2 ** window.addr_width``. Otherwise, the exact specified address
             (which must be a multiple of ``2 ** window.addr_width``) will be used.
-        sparse : bool or None
-            Address translation type. Ignored if the datapath widths of both memory maps are
-            equal; must be specified otherwise.
+        sparse : bool
+            Address translation type. Optional. Ignored if the datapath widths of both memory maps
+            are equal; must be specified otherwise.
         extend : bool
             Allow memory map extension. If ``True``, the upper bound of the address space is
             raised as needed, in order to fit a window that would otherwise be out of bounds.

--- a/amaranth_soc/wishbone/bus.py
+++ b/amaranth_soc/wishbone/bus.py
@@ -184,7 +184,7 @@ class Decoder(Elaboratable):
         Granularity. See :class:`Interface`
     features : iter(str)
         Optional signal set. See :class:`Interface`.
-    alignment : log2 of int
+    alignment : int, power-of-2 exponent
         Window alignment. See :class:`..memory.MemoryMap`
     name : str
         Window name. Optional.


### PR DESCRIPTION
* emphasize that `alignment` is a power-of-2 exponent;
* give default values of optional keyword arguments.