### PR TITLE
Migrate elaboratables to lib.wiring components.

### DIFF
--- a/amaranth_soc/csr/bus.py
+++ b/amaranth_soc/csr/bus.py
@@ -577,7 +577,7 @@ class Multiplexer(Elaboratable):
         """
         return self._map.align_to(alignment)
 
-    def add(self, element, *, name, addr=None, alignment=None, extend=False):
+    def add(self, element, *, name, addr=None, alignment=None):
         """Add a register.
 
         See :meth:`MemoryMap.add_resource` for details.
@@ -587,7 +587,7 @@ class Multiplexer(Elaboratable):
 
         size = (element.width + self._map.data_width - 1) // self._map.data_width
         return self._map.add_resource(element, size=size, addr=addr, alignment=alignment,
-                                      extend=extend, name=name)
+                                      name=name)
 
     def elaborate(self, platform):
         m = Module()
@@ -721,7 +721,7 @@ class Decoder(Elaboratable):
         """
         return self._map.align_to(alignment)
 
-    def add(self, sub_bus, *, addr=None, extend=False):
+    def add(self, sub_bus, *, addr=None):
         """Add a window to a subordinate bus.
 
         See :meth:`MemoryMap.add_resource` for details.
@@ -732,7 +732,7 @@ class Decoder(Elaboratable):
             raise ValueError(f"Subordinate bus has data width {sub_bus.data_width}, which is not "
                              f"the same as decoder data width {self._map.data_width}")
         self._subs[sub_bus.memory_map] = sub_bus
-        return self._map.add_window(sub_bus.memory_map, addr=addr, extend=extend)
+        return self._map.add_window(sub_bus.memory_map, addr=addr)
 
     def elaborate(self, platform):
         m = Module()

--- a/amaranth_soc/wishbone/bus.py
+++ b/amaranth_soc/wishbone/bus.py
@@ -342,7 +342,7 @@ class Decoder(Elaboratable):
         """
         return self._map.align_to(alignment)
 
-    def add(self, sub_bus, *, addr=None, sparse=False, extend=False):
+    def add(self, sub_bus, *, addr=None, sparse=False):
         """Add a window to a subordinate bus.
 
         The decoder can perform either sparse or dense address translation. If dense address
@@ -376,7 +376,7 @@ class Decoder(Elaboratable):
                                  f"decoder does not have a corresponding input")
 
         self._subs[sub_bus.memory_map] = sub_bus
-        return self._map.add_window(sub_bus.memory_map, addr=addr, sparse=sparse, extend=extend)
+        return self._map.add_window(sub_bus.memory_map, addr=addr, sparse=sparse)
 
     def elaborate(self, platform):
         m = Module()

--- a/amaranth_soc/wishbone/bus.py
+++ b/amaranth_soc/wishbone/bus.py
@@ -155,7 +155,7 @@ class Signature(wiring.Signature):
         Raises
         ------
         :exc:`TypeError`
-            If ``addr_width`` is not an integer greater than or equal to 0.
+            If ``addr_width`` is not an integer greater than to 0.
         :exc:`ValueError`
             If ``data_width`` is not 8, 16, 32 or 64.
         :exc:`ValueError`
@@ -165,8 +165,8 @@ class Signature(wiring.Signature):
         :exc:`ValueError`
             If ``features`` contains other values than :class:`Feature` members.
         """
-        if not isinstance(addr_width, int) or addr_width < 0:
-            raise TypeError(f"Address width must be a non-negative integer, not {addr_width!r}")
+        if not isinstance(addr_width, int) or addr_width <= 0:
+            raise TypeError(f"Address width must be a positive integer, not {addr_width!r}")
         if data_width not in (8, 16, 32, 64):
             raise ValueError(f"Data width must be one of 8, 16, 32, 64, not {data_width!r}")
         if granularity not in (8, 16, 32, 64):

--- a/tests/test_csr_bus.py
+++ b/tests/test_csr_bus.py
@@ -152,11 +152,10 @@ class InterfaceTestCase(unittest.TestCase):
         iface = csr.Interface(addr_width=16, data_width=8)
         iface.memory_map = MemoryMap(addr_width=16, data_width=8)
         with self.assertRaisesRegex(ValueError,
-                r"Memory map has been frozen. Address width cannot be extended "
-                r"further"):
-            iface.memory_map.addr_width = 24
+                r"Memory map has been frozen\. Cannot add resource 'foo'"):
+            iface.memory_map.add_resource("foo", name="foo", size=1)
 
-    def test_set_map_wrong(self):
+    def test_set_wrong_map(self):
         iface = csr.Interface(addr_width=16, data_width=8)
         with self.assertRaisesRegex(TypeError,
                 r"Memory map must be an instance of MemoryMap, not 'foo'"):
@@ -202,12 +201,6 @@ class MultiplexerTestCase(unittest.TestCase):
         elem_16b = csr.Element(16, "rw", path=("elem_16b",))
         self.assertEqual(self.dut.add(elem_16b, name="elem_16b"), (0, 2))
         self.assertEqual(self.dut.add(elem_8b,  name="elem_8b"), (2, 3))
-
-    def test_add_extend(self):
-        elem_8b = csr.Element(8, "rw", path=("elem_8b",))
-        self.assertEqual(self.dut.add(elem_8b, name="elem_8b", addr=0x10000, extend=True),
-                         (0x10000, 0x10001))
-        self.assertEqual(self.dut.bus.addr_width, 17)
 
     def test_add_wrong(self):
         with self.assertRaisesRegex(TypeError,
@@ -408,12 +401,6 @@ class DecoderTestCase(unittest.TestCase):
         sub_2 = csr.Interface(addr_width=10, data_width=8, path=("sub_2",))
         sub_2.memory_map = MemoryMap(addr_width=10, data_width=8)
         self.assertEqual(self.dut.add(sub_2), (0x1000, 0x1400, 1))
-
-    def test_add_extend(self):
-        iface = csr.Interface(addr_width=17, data_width=8, path=("iface",))
-        iface.memory_map = MemoryMap(addr_width=17, data_width=8)
-        self.assertEqual(self.dut.add(iface, extend=True), (0, 0x20000, 1))
-        self.assertEqual(self.dut.bus.addr_width, 18)
 
     def test_add_wrong_sub_bus(self):
         with self.assertRaisesRegex(TypeError,

--- a/tests/test_csr_wishbone.py
+++ b/tests/test_csr_wishbone.py
@@ -31,8 +31,8 @@ class MockRegister(Elaboratable):
 
 class WishboneCSRBridgeTestCase(unittest.TestCase):
     def test_wrong_csr_bus(self):
-        with self.assertRaisesRegex(ValueError,
-                r"CSR bus must be an instance of CSRInterface, not 'foo'"):
+        with self.assertRaisesRegex(TypeError,
+                r"CSR bus must be an instance of csr\.Interface, not 'foo'"):
             WishboneCSRBridge("foo")
 
     def test_wrong_csr_bus_data_width(self):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -53,6 +53,31 @@ class SourceSignatureTestCase(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Source.Trigger"):
             src = event.Source.Signature(trigger="foo")
 
+    def test_set_map(self):
+        sig = event.Source.Signature()
+        event_map = event.EventMap()
+        sig.event_map = event_map
+        self.assertIs(sig.event_map, event_map)
+
+    def test_get_map_none(self):
+        sig = event.Source.Signature()
+        with self.assertRaisesRegex(AttributeError,
+                r"event\.Source\.Signature\(.*\) does not have an event map"):
+            sig.event_map
+
+    def test_set_map_frozen(self):
+        sig = event.Source.Signature()
+        sig.freeze()
+        with self.assertRaisesRegex(ValueError,
+                r"Signature has been frozen\. Cannot set its event map"):
+            sig.event_map = event.EventMap()
+
+    def test_set_wrong_map(self):
+        sig = event.Source.Signature()
+        with self.assertRaisesRegex(TypeError,
+                r"Event map must be an instance of EventMap, not 'foo'"):
+            sig.event_map = "foo"
+
 
 class SourceTestCase(unittest.TestCase):
     def test_simple(self):
@@ -61,24 +86,27 @@ class SourceTestCase(unittest.TestCase):
         self.assertEqual(src.trigger, event.Source.Trigger.LEVEL)
         self.assertEqual(src.trg.name, "foo__bar__trg")
 
-    def test_get_map_wrong(self):
+    def test_map(self):
+        event_map = event.EventMap()
+        src = event.Source(event_map=event_map)
+        self.assertIs(src.event_map, event_map)
+
+    def test_get_map_none(self):
         src = event.Source()
-        with self.assertRaisesRegex(NotImplementedError,
-                r"event.Source\(.*\) does not have an event map"):
+        with self.assertRaisesRegex(AttributeError,
+                r"event\.Source\.Signature\(.*\) does not have an event map"):
             src.event_map
 
     def test_get_map_frozen(self):
-        src = event.Source()
-        src.event_map = event.EventMap()
+        src = event.Source(event_map=event.EventMap())
         with self.assertRaisesRegex(ValueError,
-                r"Event map has been frozen. Cannot add source."):
+                r"Event map has been frozen\. Cannot add source"):
             src.event_map.add(event.Source.Signature().create())
 
-    def test_set_map_wrong(self):
-        src = event.Source()
+    def test_wrong_map(self):
         with self.assertRaisesRegex(TypeError,
                 r"Event map must be an instance of EventMap, not 'foo'"):
-            src.event_map = "foo"
+            event.Source(event_map="foo")
 
 
 class EventMapTestCase(unittest.TestCase):
@@ -101,7 +129,7 @@ class EventMapTestCase(unittest.TestCase):
         event_map = event.EventMap()
         event_map.freeze()
         with self.assertRaisesRegex(ValueError,
-                r"Event map has been frozen. Cannot add source."):
+                r"Event map has been frozen. Cannot add source"):
             event_map.add(event.Source.Signature().create())
 
     def test_size(self):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -120,27 +120,6 @@ class MemoryMapTestCase(unittest.TestCase):
                 r"Alignment must be a non-negative integer, not -1"):
             MemoryMap(addr_width=16, data_width=8, alignment=-1)
 
-    def test_set_addr_width_wrong(self):
-        with self.assertRaisesRegex(ValueError,
-                r"Address width must be a positive integer, not -1"):
-            memory_map = MemoryMap(addr_width=1, data_width=8)
-            memory_map.addr_width = -1
-
-    def test_set_addr_width_wrong_shrink(self):
-        with self.assertRaisesRegex(ValueError,
-                r"Address width 1 must not be less than its previous value 2, "
-                r"because resources that were previously added may not fit anymore"):
-            memory_map = MemoryMap(addr_width=2, data_width=8)
-            memory_map.addr_width = 1
-
-    def test_set_addr_width_wrong_frozen(self):
-        with self.assertRaisesRegex(ValueError,
-                r"Memory map has been frozen. Address width cannot be extended "
-                r"further"):
-            memory_map = MemoryMap(addr_width=1, data_width=8)
-            memory_map.freeze()
-            memory_map.addr_width = 2
-
     def test_add_resource(self):
         memory_map = MemoryMap(addr_width=16, data_width=8)
         self.assertEqual(memory_map.add_resource("a", name="foo", size=1), (0, 1))
@@ -161,13 +140,6 @@ class MemoryMapTestCase(unittest.TestCase):
         memory_map = MemoryMap(addr_width=16, data_width=8)
         self.assertEqual(memory_map.add_resource("a", name="foo", size=1, addr=10), (10, 11))
         self.assertEqual(memory_map.add_resource("b", name="bar", size=2), (11, 13))
-
-    def test_add_resource_extend(self):
-        memory_map = MemoryMap(addr_width=16, data_width=8)
-        self.assertEqual(memory_map.add_resource("a", name="foo", size=1, addr=0x10000,
-                                                 extend=True),
-                         (0x10000, 0x10001))
-        self.assertEqual(memory_map.addr_width, 17)
 
     def test_add_resource_size_zero(self):
         memory_map = MemoryMap(addr_width=1, data_width=8)
@@ -270,13 +242,6 @@ class MemoryMapTestCase(unittest.TestCase):
         self.assertEqual(memory_map.add_window(MemoryMap(addr_width=10, data_width=8),
                                                sparse=False),
                          (0, 0x100, 4))
-
-    def test_add_window_extend(self):
-        memory_map = MemoryMap(addr_width=16, data_width=8)
-        self.assertEqual(memory_map.add_window(MemoryMap(addr_width=17, data_width=8),
-                                               extend=True),
-                         (0, 0x20000, 1))
-        self.assertEqual(memory_map.addr_width, 18)
 
     def test_add_window_wrong_frozen(self):
         memory_map = MemoryMap(addr_width=2, data_width=8)

--- a/tests/test_periph.py
+++ b/tests/test_periph.py
@@ -106,7 +106,7 @@ class PeripheralInfoTestCase(unittest.TestCase):
         info = PeripheralInfo(memory_map=memory_map)
         with self.assertRaisesRegex(ValueError,
                 r"Memory map has been frozen. Cannot add resource 'a'"):
-            memory_map.add_resource("a", name="foo", size=3, extend=True)
+            memory_map.add_resource("a", name="foo", size=3)
 
     def test_memory_map_wrong(self):
         with self.assertRaisesRegex(TypeError,

--- a/tests/test_wishbone_bus.py
+++ b/tests/test_wishbone_bus.py
@@ -105,45 +105,45 @@ class SignatureTestCase(unittest.TestCase):
 
     def test_wrong_addr_width(self):
         with self.assertRaisesRegex(TypeError,
-                r"Address width must be a non-negative integer, not -1"):
-            wishbone.Signature(addr_width=-1, data_width=8)
+                r"Address width must be a positive integer, not 0"):
+            wishbone.Signature(addr_width=0, data_width=8)
         with self.assertRaisesRegex(TypeError,
-                r"Address width must be a non-negative integer, not -1"):
-            wishbone.Signature.check_parameters(addr_width=-1, data_width=8, granularity=8,
+                r"Address width must be a positive integer, not 0"):
+            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=8,
                                                 features=())
 
     def test_wrong_data_width(self):
         with self.assertRaisesRegex(ValueError,
                 r"Data width must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature(addr_width=0, data_width=7)
+            wishbone.Signature(addr_width=1, data_width=7)
         with self.assertRaisesRegex(ValueError,
                 r"Data width must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature.check_parameters(addr_width=0, data_width=7, granularity=7,
+            wishbone.Signature.check_parameters(addr_width=1, data_width=7, granularity=7,
                                                 features=())
 
     def test_wrong_granularity(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature(addr_width=0, data_width=32, granularity=7)
+            wishbone.Signature(addr_width=1, data_width=32, granularity=7)
         with self.assertRaisesRegex(ValueError,
                 r"Granularity must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature.check_parameters(addr_width=0, data_width=32, granularity=7,
+            wishbone.Signature.check_parameters(addr_width=1, data_width=32, granularity=7,
                                                 features=())
 
     def test_wrong_granularity_wide(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity 32 may not be greater than data width 8"):
-            wishbone.Signature(addr_width=0, data_width=8, granularity=32)
+            wishbone.Signature(addr_width=1, data_width=8, granularity=32)
         with self.assertRaisesRegex(ValueError,
                 r"Granularity 32 may not be greater than data width 8"):
-            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=32,
+            wishbone.Signature.check_parameters(addr_width=1, data_width=8, granularity=32,
                                                 features=())
 
     def test_wrong_features(self):
         with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
-            wishbone.Signature(addr_width=0, data_width=8, features={"foo"})
+            wishbone.Signature(addr_width=1, data_width=8, features={"foo"})
         with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
-            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=8,
+            wishbone.Signature.check_parameters(addr_width=1, data_width=8, granularity=8,
                                                 features={"foo"})
 
 
@@ -158,7 +158,7 @@ class InterfaceTestCase(unittest.TestCase):
         self.assertEqual(iface.cyc.name, "foo__bar__cyc")
 
     def test_get_map_wrong(self):
-        iface = wishbone.Interface(addr_width=0, data_width=8, path=("iface",))
+        iface = wishbone.Interface(addr_width=1, data_width=8, path=("iface",))
         with self.assertRaisesRegex(NotImplementedError,
                 r"wishbone.Interface\(.*\) does not have a memory map"):
             iface.memory_map
@@ -171,7 +171,7 @@ class InterfaceTestCase(unittest.TestCase):
             iface.memory_map.add_resource("foo", name="foo", size=1)
 
     def test_set_map_wrong(self):
-        iface = wishbone.Interface(addr_width=0, data_width=8, path=("iface",))
+        iface = wishbone.Interface(addr_width=1, data_width=8, path=("iface",))
         with self.assertRaisesRegex(TypeError,
                 r"Memory map must be an instance of MemoryMap, not 'foo'"):
             iface.memory_map = "foo"

--- a/tests/test_wishbone_bus.py
+++ b/tests/test_wishbone_bus.py
@@ -167,9 +167,8 @@ class InterfaceTestCase(unittest.TestCase):
         iface = wishbone.Interface(addr_width=1, data_width=8, path=("iface",))
         iface.memory_map = MemoryMap(addr_width=1, data_width=8)
         with self.assertRaisesRegex(ValueError,
-                r"Memory map has been frozen\. Address width cannot be extended "
-                r"further"):
-            iface.memory_map.addr_width = 2
+                r"Memory map has been frozen\. Cannot add resource 'foo'"):
+            iface.memory_map.add_resource("foo", name="foo", size=1)
 
     def test_set_map_wrong(self):
         iface = wishbone.Interface(addr_width=0, data_width=8, path=("iface",))
@@ -206,12 +205,6 @@ class DecoderTestCase(unittest.TestCase):
         self.assertEqual(self.dut.align_to(18), 0x000040000)
         self.assertEqual(self.dut.align_to(alignment=18), 0x000040000)
         self.assertEqual(self.dut.add(sub_2), (0x00040000, 0x00050000, 1))
-
-    def test_add_extend(self):
-        sub = wishbone.Interface(addr_width=31, data_width=32, granularity=16, path=("sub",))
-        sub.memory_map = MemoryMap(addr_width=32, data_width=16)
-        self.assertEqual(self.dut.add(sub, addr=1, extend=True), (1, 0x100000001, 1))
-        self.assertEqual(self.dut.bus.addr_width, 32)
 
     def test_add_wrong(self):
         with self.assertRaisesRegex(TypeError,


### PR DESCRIPTION
These changes should conclude the migration of Amaranth SoC to `amaranth.lib.wiring`.