### PR TITLE
Revert "wishbone: restrict addr_width to positive integers."

### DIFF
--- a/amaranth_soc/wishbone/bus.py
+++ b/amaranth_soc/wishbone/bus.py
@@ -183,7 +183,7 @@ class Signature(wiring.Signature):
         Raises
         ------
         :exc:`TypeError`
-            If ``addr_width`` is not an integer greater than to 0.
+            If ``addr_width`` is not an integer greater than or equal to 0.
         :exc:`ValueError`
             If ``data_width`` is not 8, 16, 32 or 64.
         :exc:`ValueError`
@@ -193,8 +193,8 @@ class Signature(wiring.Signature):
         :exc:`ValueError`
             If ``features`` contains other values than :class:`Feature` members.
         """
-        if not isinstance(addr_width, int) or addr_width <= 0:
-            raise TypeError(f"Address width must be a positive integer, not {addr_width!r}")
+        if not isinstance(addr_width, int) or addr_width < 0:
+            raise TypeError(f"Address width must be a non-negative integer, not {addr_width!r}")
         if data_width not in (8, 16, 32, 64):
             raise ValueError(f"Data width must be one of 8, 16, 32, 64, not {data_width!r}")
         if granularity not in (8, 16, 32, 64):

--- a/tests/test_wishbone_bus.py
+++ b/tests/test_wishbone_bus.py
@@ -105,45 +105,45 @@ class SignatureTestCase(unittest.TestCase):
 
     def test_wrong_addr_width(self):
         with self.assertRaisesRegex(TypeError,
-                r"Address width must be a positive integer, not 0"):
-            wishbone.Signature(addr_width=0, data_width=8)
+                r"Address width must be a non-negative integer, not -1"):
+            wishbone.Signature(addr_width=-1, data_width=8)
         with self.assertRaisesRegex(TypeError,
-                r"Address width must be a positive integer, not 0"):
-            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=8,
+                r"Address width must be a non-negative integer, not -1"):
+            wishbone.Signature.check_parameters(addr_width=-1, data_width=8, granularity=8,
                                                 features=())
 
     def test_wrong_data_width(self):
         with self.assertRaisesRegex(ValueError,
                 r"Data width must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature(addr_width=1, data_width=7)
+            wishbone.Signature(addr_width=0, data_width=7)
         with self.assertRaisesRegex(ValueError,
                 r"Data width must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature.check_parameters(addr_width=1, data_width=7, granularity=7,
+            wishbone.Signature.check_parameters(addr_width=0, data_width=7, granularity=7,
                                                 features=())
 
     def test_wrong_granularity(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature(addr_width=1, data_width=32, granularity=7)
+            wishbone.Signature(addr_width=0, data_width=32, granularity=7)
         with self.assertRaisesRegex(ValueError,
                 r"Granularity must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature.check_parameters(addr_width=1, data_width=32, granularity=7,
+            wishbone.Signature.check_parameters(addr_width=0, data_width=32, granularity=7,
                                                 features=())
 
     def test_wrong_granularity_wide(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity 32 may not be greater than data width 8"):
-            wishbone.Signature(addr_width=1, data_width=8, granularity=32)
+            wishbone.Signature(addr_width=0, data_width=8, granularity=32)
         with self.assertRaisesRegex(ValueError,
                 r"Granularity 32 may not be greater than data width 8"):
-            wishbone.Signature.check_parameters(addr_width=1, data_width=8, granularity=32,
+            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=32,
                                                 features=())
 
     def test_wrong_features(self):
         with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
-            wishbone.Signature(addr_width=1, data_width=8, features={"foo"})
+            wishbone.Signature(addr_width=0, data_width=8, features={"foo"})
         with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
-            wishbone.Signature.check_parameters(addr_width=1, data_width=8, granularity=8,
+            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=8,
                                                 features={"foo"})
 
     def test_set_map(self):
@@ -203,7 +203,7 @@ class InterfaceTestCase(unittest.TestCase):
         self.assertIs(iface.memory_map, memory_map)
 
     def test_get_map_none(self):
-        iface = wishbone.Interface(addr_width=1, data_width=8, path=("iface",))
+        iface = wishbone.Interface(addr_width=0, data_width=8, path=("iface",))
         with self.assertRaisesRegex(AttributeError,
                 r"wishbone.Signature\(.*\) does not have a memory map"):
             iface.memory_map
@@ -211,7 +211,7 @@ class InterfaceTestCase(unittest.TestCase):
     def test_wrong_map(self):
         with self.assertRaisesRegex(TypeError,
                 r"Memory map must be an instance of MemoryMap, not 'foo'"):
-            wishbone.Interface(addr_width=1, data_width=8, memory_map="foo")
+            wishbone.Interface(addr_width=0, data_width=8, memory_map="foo")
 
     def test_wrong_map_data_width(self):
         with self.assertRaisesRegex(ValueError,


### PR DESCRIPTION
This reverts commit 1b25700ed2a62ddf8d3733c6f5ee28b83c466d99.

Wishbone bus interfaces with 0-bit address widths are explicitly allowed by the specification, and may occur in some cases such as peripherals with FIFO-like interfaces.