### PR TITLE
Rename wiring.Interface to wiring.PureInterface

### DIFF
--- a/amaranth_soc/csr/bus.py
+++ b/amaranth_soc/csr/bus.py
@@ -10,7 +10,7 @@ from ..memory import MemoryMap
 __all__ = ["Element", "Signature", "Interface", "Decoder", "Multiplexer"]
 
 
-class Element(wiring.Interface):
+class Element(wiring.PureInterface):
     class Access(enum.Enum):
         """Register access mode.
 
@@ -138,7 +138,7 @@ class Element(wiring.Interface):
     access : :class:`Element.Access`
         Register access mode.
     path : iter(:class:`str`)
-        Path to this CSR interface. Optional. See :class:`wiring.Interface`.
+        Path to this CSR interface. Optional. See :class:`wiring.PureInterface`.
 
     Raises
     ------
@@ -280,7 +280,7 @@ class Signature(wiring.Signature):
         return f"csr.Signature({self.members!r})"
 
 
-class Interface(wiring.Interface):
+class Interface(wiring.PureInterface):
     """CPU-side CSR interface.
 
     A low-level interface to a set of atomically readable and writable peripheral CSR registers.
@@ -307,7 +307,7 @@ class Interface(wiring.Interface):
     memory_map: :class:`MemoryMap`
         Memory map of the bus. Optional. See :class:`Signature`.
     path : iter(:class:`str`)
-        Path to this CSR interface. Optional. See :class:`wiring.Interface`.
+        Path to this CSR interface. Optional. See :class:`wiring.PureInterface`.
 
     Raises
     ------

--- a/amaranth_soc/event.py
+++ b/amaranth_soc/event.py
@@ -6,7 +6,7 @@ from amaranth.lib.wiring import In, Out
 __all__ = ["Source", "EventMap", "Monitor"]
 
 
-class Source(wiring.Interface):
+class Source(wiring.PureInterface):
     class Trigger(enum.Enum):
         """Event trigger mode."""
         LEVEL = "level"
@@ -110,7 +110,7 @@ class Source(wiring.Interface):
     trigger : :class:`Source.Trigger`
         Trigger mode. An event can be edge- or level-triggered by the input line.
     path : iter(:class:`str`)
-        Path to this event source interface. Optional. See :class:`wiring.Interface`.
+        Path to this event source interface. Optional. See :class:`wiring.PureInterface`.
 
     Attributes
     ----------

--- a/amaranth_soc/wishbone/bus.py
+++ b/amaranth_soc/wishbone/bus.py
@@ -235,7 +235,7 @@ class Signature(wiring.Signature):
         return f"wishbone.Signature({self.members!r})"
 
 
-class Interface(wiring.Interface):
+class Interface(wiring.PureInterface):
     """Wishbone bus interface.
 
     Note that the data width of the underlying memory map of the interface is equal to port
@@ -255,7 +255,7 @@ class Interface(wiring.Interface):
     memory_map: :class:`MemoryMap`
         Memory map of the bus. Optional. See :class:`Signature`.
     path : iter(:class:`str`)
-        Path to this Wishbone interface. Optional. See :class:`wiring.Interface`.
+        Path to this Wishbone interface. Optional. See :class:`wiring.PureInterface`.
 
     Raises
     ------


### PR DESCRIPTION
Due to Amaranth renaming its `Interface` class to `PureInterface` in commit https://github.com/amaranth-lang/amaranth/commit/0cdcab0fbbdd86390fd32105f695a164e0826ab8 importing anything that uses `wiring.Interface` fails. This commit introduces necessary renames to make it compatible with the latest Amaranth.