### PR TITLE
Update to follow RFCs 37 and 38.

### DIFF
--- a/amaranth_soc/csr/wishbone.py
+++ b/amaranth_soc/csr/wishbone.py
@@ -51,25 +51,19 @@ class WishboneCSRBridge(wiring.Component):
         if data_width is None:
             data_width = csr_bus.data_width
 
-        wb_signature = wishbone.Signature(
-            addr_width=max(0, csr_bus.addr_width - log2_int(data_width // csr_bus.data_width)),
-            data_width=data_width,
-            granularity=csr_bus.data_width)
+        wb_sig = wishbone.Signature(addr_width=max(0, csr_bus.addr_width -
+                                                      log2_int(data_width // csr_bus.data_width)),
+                                    data_width=data_width, granularity=csr_bus.data_width)
 
-        wb_signature.memory_map = MemoryMap(addr_width=csr_bus.addr_width,
-                                            data_width=csr_bus.data_width,
-                                            name=name)
+        super().__init__({"wb_bus": In(wb_sig)})
+
+        self.wb_bus.memory_map = MemoryMap(addr_width=csr_bus.addr_width,
+                                           data_width=csr_bus.data_width, name=name)
         # Since granularity of the Wishbone interface matches the data width of the CSR bus,
         # no width conversion is performed, even if the Wishbone data width is greater.
-        wb_signature.memory_map.add_window(csr_bus.memory_map)
+        self.wb_bus.memory_map.add_window(csr_bus.memory_map)
 
-        self._signature = wiring.Signature({"wb_bus": In(wb_signature)})
-        self._csr_bus   = csr_bus
-        super().__init__()
-
-    @property
-    def signature(self):
-        return self._signature
+        self._csr_bus = csr_bus
 
     @property
     def csr_bus(self):

--- a/tests/test_csr_bus.py
+++ b/tests/test_csr_bus.py
@@ -134,45 +134,6 @@ class SignatureTestCase(unittest.TestCase):
                 r"Data width must be a positive integer, not -1"):
             csr.Signature.check_parameters(addr_width=16, data_width=-1)
 
-    def test_set_map(self):
-        sig = csr.Signature(addr_width=16, data_width=16)
-        memory_map = MemoryMap(addr_width=16, data_width=16)
-        sig.memory_map = memory_map
-        self.assertIs(sig.memory_map, memory_map)
-
-    def test_get_map_none(self):
-        sig = csr.Signature(addr_width=1, data_width=8)
-        with self.assertRaisesRegex(AttributeError,
-                r"csr.Signature\(.*\) does not have a memory map"):
-            sig.memory_map
-
-    def test_set_map_frozen(self):
-        sig = csr.Signature(addr_width=8, data_width=8)
-        sig.freeze()
-        with self.assertRaisesRegex(ValueError,
-                r"Signature has been frozen\. Cannot set its memory map"):
-            sig.memory_map = MemoryMap(addr_width=8, data_width=8)
-
-    def test_set_wrong_map(self):
-        sig = csr.Signature(addr_width=8, data_width=8)
-        with self.assertRaisesRegex(TypeError,
-                r"Memory map must be an instance of MemoryMap, not 'foo'"):
-            sig.memory_map = "foo"
-
-    def test_set_wrong_map_addr_width(self):
-        sig = csr.Signature(addr_width=8, data_width=8)
-        with self.assertRaisesRegex(ValueError,
-                r"Memory map has address width 7, which is not the same as bus interface address "
-                r"width 8"):
-            sig.memory_map = MemoryMap(addr_width=7, data_width=8)
-
-    def test_set_wrong_map_data_width(self):
-        sig = csr.Signature(addr_width=8, data_width=8)
-        with self.assertRaisesRegex(ValueError,
-                r"Memory map has data width 7, which is not the same as bus interface data width "
-                r"8"):
-            sig.memory_map = MemoryMap(addr_width=8, data_width=7)
-
 
 class InterfaceTestCase(unittest.TestCase):
     def test_simple(self):
@@ -181,35 +142,37 @@ class InterfaceTestCase(unittest.TestCase):
         self.assertEqual(iface.data_width, 8)
         self.assertEqual(iface.r_stb.name, "foo__bar__r_stb")
 
-    def test_map(self):
+    def test_set_map(self):
+        iface = csr.Interface(addr_width=12, data_width=8)
         memory_map = MemoryMap(addr_width=12, data_width=8)
-        iface = csr.Interface(addr_width=12, data_width=8, memory_map=memory_map, path=("iface",))
+        iface.memory_map = memory_map
         self.assertIs(iface.memory_map, memory_map)
 
     def test_get_map_none(self):
-        iface = csr.Interface(addr_width=16, data_width=8, path=("iface",))
+        iface = csr.Interface(addr_width=16, data_width=8)
         with self.assertRaisesRegex(AttributeError,
-                r"csr.Signature\(.*\) does not have a memory map"):
+                r"csr.Interface\(.*\) does not have a memory map"):
             iface.memory_map
 
-    def test_wrong_map(self):
+    def test_set_wrong_map(self):
+        iface = csr.Interface(addr_width=16, data_width=8)
         with self.assertRaisesRegex(TypeError,
                 r"Memory map must be an instance of MemoryMap, not 'foo'"):
-            csr.Interface(addr_width=16, data_width=8, memory_map="foo")
+            iface.memory_map = "foo"
 
-    def test_wrong_map_addr_width(self):
+    def test_set_wrong_map_addr_width(self):
+        iface = csr.Interface(addr_width=8, data_width=8)
         with self.assertRaisesRegex(ValueError,
-                r"Memory map has address width 8, which is not the same as "
-                r"bus interface address width 16"):
-            csr.Interface(addr_width=16, data_width=8,
-                          memory_map=MemoryMap(addr_width=8, data_width=8))
+                r"Memory map has address width 7, which is not the same as bus interface address "
+                r"width 8"):
+            iface.memory_map = MemoryMap(addr_width=7, data_width=8)
 
-    def test_wrong_map_data_width(self):
+    def test_set_wrong_map_data_width(self):
+        iface = csr.Interface(addr_width=8, data_width=8)
         with self.assertRaisesRegex(ValueError,
-                r"Memory map has data width 16, which is not the same as "
-                r"bus interface data width 8"):
-            csr.Interface(addr_width=16, data_width=8,
-                          memory_map=MemoryMap(addr_width=16, data_width=16))
+                r"Memory map has data width 7, which is not the same as bus interface data width "
+                r"8"):
+            iface.memory_map = MemoryMap(addr_width=8, data_width=7)
 
 
 class MultiplexerTestCase(unittest.TestCase):
@@ -427,17 +390,15 @@ class DecoderTestCase(unittest.TestCase):
         self.dut = csr.Decoder(addr_width=16, data_width=8)
 
     def test_align_to(self):
-        sig_1 = csr.Signature(addr_width=10, data_width=8)
-        sig_1.memory_map = MemoryMap(addr_width=10, data_width=8)
-        sub_1 = sig_1.create(path=("sub_1",))
+        sub_1 = csr.Interface(addr_width=10, data_width=8)
+        sub_1.memory_map = MemoryMap(addr_width=10, data_width=8)
         self.assertEqual(self.dut.add(sub_1), (0, 0x400, 1))
 
         self.assertEqual(self.dut.align_to(12), 0x1000)
         self.assertEqual(self.dut.align_to(alignment=12), 0x1000)
 
-        sig_2 = csr.Signature(addr_width=10, data_width=8)
-        sig_2.memory_map = MemoryMap(addr_width=10, data_width=8)
-        sub_2 = sig_2.create(path=("sub_2",))
+        sub_2 = csr.Interface(addr_width=10, data_width=8)
+        sub_2.memory_map = MemoryMap(addr_width=10, data_width=8)
         self.assertEqual(self.dut.add(sub_2), (0x1000, 0x1400, 1))
 
     def test_add_wrong_sub_bus(self):
@@ -455,9 +416,8 @@ class DecoderTestCase(unittest.TestCase):
             self.dut.add(mux.bus)
 
     def test_add_wrong_out_of_bounds(self):
-        iface = csr.Interface(addr_width=17, data_width=8,
-                              memory_map=MemoryMap(addr_width=17, data_width=8),
-                              path=("iface",))
+        iface = csr.Interface(addr_width=17, data_width=8)
+        iface.memory_map = MemoryMap(addr_width=17, data_width=8)
         with self.assertRaisesRegex(ValueError,
                 r"Address range 0x0\.\.0x20000 out of bounds for memory map spanning "
                 r"range 0x0\.\.0x10000 \(16 address bits\)"):

--- a/tests/test_csr_event.py
+++ b/tests/test_csr_event.py
@@ -52,10 +52,10 @@ class EventMonitorTestCase(unittest.TestCase):
         event_map.add(sub_0)
         event_map.add(sub_1)
         monitor = EventMonitor(event_map, data_width=8)
-        resources = list(monitor.bus.memory_map.resources())
+        resources = list(monitor.bus.memory_map.all_resources())
         self.assertEqual(len(resources), 2)
-        enable,  enable_name,  enable_range  = resources[0]
-        pending, pending_name, pending_range = resources[1]
+        enable,   enable_range = resources[0].resource, (resources[0].start, resources[0].end)
+        pending, pending_range = resources[1].resource, (resources[1].start, resources[1].end)
         self.assertEqual(
             (enable.width, enable.access, enable_range),
             (2, Element.Access.RW, (0, 1))
@@ -68,7 +68,7 @@ class EventMonitorTestCase(unittest.TestCase):
 
 class EventMonitorSimulationTestCase(unittest.TestCase):
     def test_simple(self):
-        sub = event.Source(path=("sub",))
+        sub = event.Source()
         event_map = event.EventMap()
         event_map.add(sub)
         dut = EventMonitor(event_map, data_width=8)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -53,31 +53,6 @@ class SourceSignatureTestCase(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Source.Trigger"):
             src = event.Source.Signature(trigger="foo")
 
-    def test_set_map(self):
-        sig = event.Source.Signature()
-        event_map = event.EventMap()
-        sig.event_map = event_map
-        self.assertIs(sig.event_map, event_map)
-
-    def test_get_map_none(self):
-        sig = event.Source.Signature()
-        with self.assertRaisesRegex(AttributeError,
-                r"event\.Source\.Signature\(.*\) does not have an event map"):
-            sig.event_map
-
-    def test_set_map_frozen(self):
-        sig = event.Source.Signature()
-        sig.freeze()
-        with self.assertRaisesRegex(ValueError,
-                r"Signature has been frozen\. Cannot set its event map"):
-            sig.event_map = event.EventMap()
-
-    def test_set_wrong_map(self):
-        sig = event.Source.Signature()
-        with self.assertRaisesRegex(TypeError,
-                r"Event map must be an instance of EventMap, not 'foo'"):
-            sig.event_map = "foo"
-
 
 class SourceTestCase(unittest.TestCase):
     def test_simple(self):
@@ -86,27 +61,30 @@ class SourceTestCase(unittest.TestCase):
         self.assertEqual(src.trigger, event.Source.Trigger.LEVEL)
         self.assertEqual(src.trg.name, "foo__bar__trg")
 
-    def test_map(self):
+    def test_set_map(self):
+        src = event.Source()
         event_map = event.EventMap()
-        src = event.Source(event_map=event_map)
+        src.event_map = event_map
         self.assertIs(src.event_map, event_map)
 
     def test_get_map_none(self):
         src = event.Source()
         with self.assertRaisesRegex(AttributeError,
-                r"event\.Source\.Signature\(.*\) does not have an event map"):
+                r"event\.Source\(.*\) does not have an event map"):
             src.event_map
 
     def test_get_map_frozen(self):
-        src = event.Source(event_map=event.EventMap())
+        src = event.Source()
+        src.event_map = event.EventMap()
         with self.assertRaisesRegex(ValueError,
                 r"Event map has been frozen\. Cannot add source"):
             src.event_map.add(event.Source.Signature().create())
 
-    def test_wrong_map(self):
+    def test_set_wrong_map(self):
+        src = event.Source()
         with self.assertRaisesRegex(TypeError,
                 r"Event map must be an instance of EventMap, not 'foo'"):
-            event.Source(event_map="foo")
+            src.event_map = "foo"
 
 
 class EventMapTestCase(unittest.TestCase):
@@ -139,8 +117,8 @@ class EventMapTestCase(unittest.TestCase):
         self.assertEqual(event_map.size, 2)
 
     def test_index(self):
-        src_0 = event.Source(path=("src_0",))
-        src_1 = event.Source(path=("src_1",))
+        src_0 = event.Source()
+        src_1 = event.Source()
         event_map = event.EventMap()
         event_map.add(src_0)
         event_map.add(src_1)
@@ -148,7 +126,7 @@ class EventMapTestCase(unittest.TestCase):
         self.assertEqual(event_map.index(src=src_1), 1)
 
     def test_index_add_twice(self):
-        src = event.Source(path=("src",))
+        src = event.Source()
         event_map = event.EventMap()
         event_map.add(src)
         event_map.add(src)
@@ -162,14 +140,14 @@ class EventMapTestCase(unittest.TestCase):
             event_map.index("foo")
 
     def test_index_not_found(self):
-        src = event.Source(path=("src",))
+        src = event.Source()
         event_map = event.EventMap()
         with self.assertRaises(KeyError):
             event_map.index(src)
 
     def test_iter_sources(self):
-        src_0 = event.Source(path=("src_0",))
-        src_1 = event.Source(path=("src_1",))
+        src_0 = event.Source()
+        src_1 = event.Source()
         event_map = event.EventMap()
         event_map.add(src_0)
         event_map.add(src_1)

--- a/tests/test_wishbone_bus.py
+++ b/tests/test_wishbone_bus.py
@@ -72,12 +72,11 @@ class SignatureTestCase(unittest.TestCase):
 
     def test_create(self):
         sig   = wishbone.Signature(addr_width=32, data_width=16, granularity=8)
-        iface = sig.create(path=("foo", "bar"))
+        iface = sig.create(path=("iface",))
         self.assertIsInstance(iface, wishbone.Interface)
         self.assertEqual(iface.addr_width, 32)
         self.assertEqual(iface.data_width, 16)
         self.assertEqual(iface.granularity, 8)
-        self.assertEqual(iface.cyc.name, "foo__bar__cyc")
         self.assertEqual(iface.signature, sig)
 
     def test_eq(self):
@@ -146,86 +145,46 @@ class SignatureTestCase(unittest.TestCase):
             wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=8,
                                                 features={"foo"})
 
-    def test_set_map(self):
-        sig = wishbone.Signature(addr_width=15, data_width=16, granularity=8)
-        memory_map = MemoryMap(addr_width=16, data_width=8)
-        sig.memory_map = memory_map
-        self.assertIs(sig.memory_map, memory_map)
-
-    def test_get_map_none(self):
-        sig = wishbone.Signature(addr_width=8, data_width=8)
-        with self.assertRaisesRegex(AttributeError,
-                r"wishbone.Signature\(.*\) does not have a memory map"):
-            sig.memory_map
-
-    def test_set_map_frozen(self):
-        sig = wishbone.Signature(addr_width=8, data_width=8)
-        sig.freeze()
-        with self.assertRaisesRegex(ValueError,
-                r"Signature has been frozen\. Cannot set its memory map"):
-            sig.memory_map = MemoryMap(addr_width=8, data_width=8)
-
-    def test_set_wrong_map(self):
-        sig = wishbone.Signature(addr_width=8, data_width=8)
-        with self.assertRaisesRegex(TypeError,
-                r"Memory map must be an instance of MemoryMap, not 'foo'"):
-            sig.memory_map = "foo"
-
-    def test_set_wrong_map_data_width(self):
-        sig = wishbone.Signature(addr_width=30, data_width=32, granularity=8)
-        with self.assertRaisesRegex(ValueError,
-                r"Memory map has data width 32, which is not the same as bus "
-                r"interface granularity 8"):
-            sig.memory_map = MemoryMap(addr_width=32, data_width=32)
-
-    def test_set_wrong_map_addr_width(self):
-        sig = wishbone.Signature(addr_width=30, data_width=32, granularity=8)
-        with self.assertRaisesRegex(ValueError,
-                r"Memory map has address width 30, which is not the same as the bus interface "
-                r"effective address width 32 \(= 30 address bits \+ 2 granularity bits\)"):
-            sig.memory_map = MemoryMap(addr_width=30, data_width=8)
-
 
 class InterfaceTestCase(unittest.TestCase):
     def test_simple(self):
-        iface = wishbone.Interface(addr_width=32, data_width=8, features={"err"},
-                                   path=("foo", "bar"))
+        iface = wishbone.Interface(addr_width=32, data_width=8, features={"err"})
         self.assertEqual(iface.addr_width, 32)
         self.assertEqual(iface.data_width, 8)
         self.assertEqual(iface.granularity, 8)
         self.assertEqual(iface.features, {wishbone.Feature.ERR})
-        self.assertEqual(iface.cyc.name, "foo__bar__cyc")
 
-    def test_map(self):
-        memory_map = MemoryMap(addr_width=32, data_width=8)
-        iface = wishbone.Interface(addr_width=30, data_width=32, granularity=8,
-                                   memory_map=memory_map, path=("iface",))
+    def test_set_map(self):
+        iface = wishbone.Interface(addr_width=15, data_width=16, granularity=8)
+        memory_map = MemoryMap(addr_width=16, data_width=8)
+        iface.memory_map = memory_map
         self.assertIs(iface.memory_map, memory_map)
 
     def test_get_map_none(self):
-        iface = wishbone.Interface(addr_width=0, data_width=8, path=("iface",))
+        iface = wishbone.Interface(addr_width=8, data_width=8)
         with self.assertRaisesRegex(AttributeError,
-                r"wishbone.Signature\(.*\) does not have a memory map"):
+                r"wishbone.Interface\(.*\) does not have a memory map"):
             iface.memory_map
 
-    def test_wrong_map(self):
+    def test_set_wrong_map(self):
+        iface = wishbone.Interface(addr_width=8, data_width=8)
         with self.assertRaisesRegex(TypeError,
                 r"Memory map must be an instance of MemoryMap, not 'foo'"):
-            wishbone.Interface(addr_width=0, data_width=8, memory_map="foo")
+            iface.memory_map = "foo"
 
-    def test_wrong_map_data_width(self):
+    def test_set_wrong_map_data_width(self):
+        iface = wishbone.Interface(addr_width=30, data_width=32, granularity=8)
         with self.assertRaisesRegex(ValueError,
                 r"Memory map has data width 32, which is not the same as bus "
                 r"interface granularity 8"):
-            wishbone.Interface(addr_width=30, data_width=32, granularity=8,
-                               memory_map=MemoryMap(addr_width=32, data_width=32))
+            iface.memory_map = MemoryMap(addr_width=32, data_width=32)
 
-    def test_wrong_map_addr_width(self):
+    def test_set_wrong_map_addr_width(self):
+        iface = wishbone.Interface(addr_width=30, data_width=32, granularity=8)
         with self.assertRaisesRegex(ValueError,
                 r"Memory map has address width 30, which is not the same as the bus interface "
                 r"effective address width 32 \(= 30 address bits \+ 2 granularity bits\)"):
-            wishbone.Interface(addr_width=30, data_width=32, granularity=8,
-                               memory_map=MemoryMap(addr_width=30, data_width=8))
+            iface.memory_map = MemoryMap(addr_width=30, data_width=8)
 
 
 class DecoderTestCase(unittest.TestCase):
@@ -233,12 +192,10 @@ class DecoderTestCase(unittest.TestCase):
         self.dut = wishbone.Decoder(addr_width=31, data_width=32, granularity=16)
 
     def test_add_align_to(self):
-        sig_1 = wishbone.Signature(addr_width=15, data_width=32, granularity=16)
-        sig_1.memory_map = MemoryMap(addr_width=16, data_width=16)
-        sig_2 = wishbone.Signature(addr_width=15, data_width=32, granularity=16)
-        sig_2.memory_map = MemoryMap(addr_width=16, data_width=16)
-        sub_1 = sig_1.create(path=("sub_1"))
-        sub_2 = sig_2.create(path=("sub_2"))
+        sub_1 = wishbone.Interface(addr_width=15, data_width=32, granularity=16)
+        sub_1.memory_map = MemoryMap(addr_width=16, data_width=16)
+        sub_2 = wishbone.Interface(addr_width=15, data_width=32, granularity=16)
+        sub_2.memory_map = MemoryMap(addr_width=16, data_width=16)
         self.assertEqual(self.dut.add(sub_1), (0x00000000, 0x00010000, 1))
         self.assertEqual(self.dut.align_to(18), 0x000040000)
         self.assertEqual(self.dut.align_to(alignment=18), 0x000040000)
@@ -250,38 +207,36 @@ class DecoderTestCase(unittest.TestCase):
             self.dut.add(sub_bus="foo")
 
     def test_add_wrong_granularity(self):
-        sub = wishbone.Interface(addr_width=15, data_width=32, granularity=32, path=("sub",))
+        sub = wishbone.Interface(addr_width=15, data_width=32, granularity=32)
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has granularity 32, which is greater than "
                 r"the decoder granularity 16"):
             self.dut.add(sub)
 
     def test_add_wrong_width_dense(self):
-        sub = wishbone.Interface(addr_width=15, data_width=16, granularity=16, path=("sub",))
+        sub = wishbone.Interface(addr_width=15, data_width=16, granularity=16)
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has data width 16, which is not the same as decoder "
                 r"data width 32 \(required for dense address translation\)"):
             self.dut.add(sub)
 
     def test_add_wrong_granularity_sparse(self):
-        sub = wishbone.Interface(addr_width=15, data_width=64, granularity=16, path=("sub",))
+        sub = wishbone.Interface(addr_width=15, data_width=64, granularity=16)
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has data width 64, which is not the same as its "
                 r"granularity 16 \(required for sparse address translation\)"):
             self.dut.add(sub, sparse=True)
 
     def test_add_wrong_optional_output(self):
-        sub = wishbone.Interface(addr_width=15, data_width=32, granularity=16, features={"err"},
-                                 path=("sub",))
+        sub = wishbone.Interface(addr_width=15, data_width=32, granularity=16, features={"err"})
         with self.assertRaisesRegex(ValueError,
                 r"Subordinate bus has optional output 'err', but the decoder does "
                 r"not have a corresponding input"):
             self.dut.add(sub)
 
     def test_add_wrong_out_of_bounds(self):
-        sub = wishbone.Interface(addr_width=31, data_width=32, granularity=16,
-                                 memory_map=MemoryMap(addr_width=32, data_width=16),
-                                 path=("sub",))
+        sub = wishbone.Interface(addr_width=31, data_width=32, granularity=16)
+        sub.memory_map = MemoryMap(addr_width=32, data_width=16)
         with self.assertRaisesRegex(ValueError,
             r"Address range 0x1\.\.0x100000001 out of bounds for memory map spanning "
             r"range 0x0\.\.0x100000000 \(32 address bits\)"):
@@ -292,14 +247,12 @@ class DecoderSimulationTestCase(unittest.TestCase):
     def test_simple(self):
         dut = wishbone.Decoder(addr_width=30, data_width=32, granularity=8,
                                features={"err", "rty", "stall", "lock", "cti", "bte"})
-        sub_1 = wishbone.Interface(addr_width=14, data_width=32, granularity=8,
-                                   memory_map=MemoryMap(addr_width=16, data_width=8),
-                                   path=("sub_1",))
+        sub_1 = wishbone.Interface(addr_width=14, data_width=32, granularity=8)
+        sub_1.memory_map = MemoryMap(addr_width=16, data_width=8)
         dut.add(sub_1, addr=0x10000)
         sub_2 = wishbone.Interface(addr_width=14, data_width=32, granularity=8,
-                                   features={"err", "rty", "stall", "lock", "cti", "bte"},
-                                   memory_map=MemoryMap(addr_width=16, data_width=8),
-                                   path=("sub_2",))
+                                   features={"err", "rty", "stall", "lock", "cti", "bte"})
+        sub_2.memory_map = MemoryMap(addr_width=16, data_width=8)
         dut.add(sub_2)
 
         def sim_test():
@@ -355,7 +308,7 @@ class DecoderSimulationTestCase(unittest.TestCase):
     def test_addr_translate(self):
         class AddressLoopback(Elaboratable):
             def __init__(self, **kwargs):
-                self.bus = wishbone.Interface(path=("bus",), **kwargs)
+                self.bus = wishbone.Interface(**kwargs)
 
             def elaborate(self, platform):
                 m = Module()
@@ -368,20 +321,20 @@ class DecoderSimulationTestCase(unittest.TestCase):
                 return m
 
         dut = wishbone.Decoder(addr_width=20, data_width=32, granularity=16)
-        loop_1 = AddressLoopback(addr_width=7, data_width=32, granularity=16,
-                                 memory_map=MemoryMap(addr_width=8, data_width=16))
+        loop_1 = AddressLoopback(addr_width=7, data_width=32, granularity=16)
+        loop_1.bus.memory_map = MemoryMap(addr_width=8, data_width=16)
         self.assertEqual(dut.add(loop_1.bus, addr=0x10000),
                          (0x10000, 0x10100, 1))
-        loop_2 = AddressLoopback(addr_width=6, data_width=32, granularity=8,
-                                 memory_map=MemoryMap(addr_width=8, data_width=8))
+        loop_2 = AddressLoopback(addr_width=6, data_width=32, granularity=8)
+        loop_2.bus.memory_map = MemoryMap(addr_width=8, data_width=8)
         self.assertEqual(dut.add(loop_2.bus, addr=0x20000),
                          (0x20000, 0x20080, 2))
-        loop_3 = AddressLoopback(addr_width=8, data_width=16, granularity=16,
-                                 memory_map=MemoryMap(addr_width=8, data_width=16))
+        loop_3 = AddressLoopback(addr_width=8, data_width=16, granularity=16)
+        loop_3.bus.memory_map = MemoryMap(addr_width=8, data_width=16)
         self.assertEqual(dut.add(loop_3.bus, addr=0x30000, sparse=True),
                          (0x30000, 0x30100, 1))
-        loop_4 = AddressLoopback(addr_width=8, data_width=8,  granularity=8,
-                                 memory_map=MemoryMap(addr_width=8, data_width=8))
+        loop_4 = AddressLoopback(addr_width=8, data_width=8,  granularity=8)
+        loop_4.bus.memory_map = MemoryMap(addr_width=8, data_width=8)
         self.assertEqual(dut.add(loop_4.bus, addr=0x40000, sparse=True),
                          (0x40000, 0x40100, 1))
 
@@ -465,9 +418,8 @@ class DecoderSimulationTestCase(unittest.TestCase):
 
     def test_coarse_granularity(self):
         dut = wishbone.Decoder(addr_width=3, data_width=32)
-        sub = wishbone.Interface(addr_width=2, data_width=32,
-                                 memory_map=MemoryMap(addr_width=2, data_width=32),
-                                 path=("sub",))
+        sub = wishbone.Interface(addr_width=2, data_width=32)
+        sub.memory_map = MemoryMap(addr_width=2, data_width=32)
         dut.add(sub)
 
         def sim_test():


### PR DESCRIPTION
Memory maps and event maps are now assigned to Interface objects instead of Signature objects (which can no longer hold mutable state), as things were before 9ffaf949.

See #62.