### PR TITLE
Mark amaranth dependency similarly to other projects.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {file = "LICENSE.txt"}
 requires-python = "~=3.8"
 dependencies = [
   # this version requirement needs to be synchronized with the one in .github/workflows/main.yml
-  "amaranth@git+https://github.com/amaranth-lang/amaranth",
+  "amaranth@git+https://github.com/amaranth-lang/amaranth.git@main",
 ]
 
 [project.urls]


### PR DESCRIPTION
While building deca-usb2-audio-interface I run into strange package conflict:
```
(...)
The conflict is caused by:
    The user requested amaranth 0.4.1.dev37+gae36b59 (from git+https://github.com/amaranth-lang/amaranth.git@main)
    amaranth-boards 0.1.dev241+g1706758 depends on amaranth<0.5 and >=0.4
    luna 0.1.0.dev0 depends on amaranth 0.4.1.dev37+gae36b59 (from git+https://github.com/amaranth-lang/amaranth.git@main)
    amlib 0.1.dev164+gc11c69d depends on amaranth>=0.2
    amaranth-soc 0.1.dev81+gdc96bde depends on amaranth 0.4.1.dev37+gae36b59 (from git+https://github.com/amaranth-lang/amaranth)
(...)
```
As it is visible, amaranth in amaranth-soc differs from other amaranth inclusion (luna or user request). This fix sets correct repo address and branch, solving the conflict.