### PR TITLE
csr.bus: elaborate Multiplexer connections deterministically

### DIFF
--- a/amaranth_soc/csr/bus.py
+++ b/amaranth_soc/csr/bus.py
@@ -472,7 +472,10 @@ class Multiplexer(wiring.Component):
             registers = defaultdict(list)
             balanced  = True
 
-            for reg_range in self._ranges:
+            # sort ranges in an arbitrary but nice fashion so that we build registers and so create
+            # chunks and elaborate their connections deterministically
+            ranges = sorted(self._ranges, key=lambda r: (r.start, r.stop, r.step))
+            for reg_range in ranges:
                 for chunk_addr in reg_range:
                     chunk_offset = self.decode_address(chunk_addr, reg_range)
                     if len(registers[chunk_offset]) > self.overlaps:


### PR DESCRIPTION
Python sets have non-deterministic iteration, however dicts iterate in insertion order.

Ensuring the Shadow range set is iterated in a deterministic order causes chunks to be built in a deterministic order and thus chunks/registers to be processed in a deterministic order inside `elaborate()`.

If they are processed non-deterministically, then the Case ordering and various temporary variable names are produced non-deterministically, causing a non-deterministic final RTLIL output, which is undesirable.

Determinism is one of those things that's rather hard to prove true, but this nonetheless fixes a tested design's RTLIL output to be deterministic across all (several dozen) tested runs rather than be different almost every run.