### PR TITLE
Remove .check_parameters() method from signatures.

### DIFF
--- a/amaranth_soc/csr/reg.py
+++ b/amaranth_soc/csr/reg.py
@@ -51,13 +51,20 @@ class FieldPort(wiring.PureInterface):
         w_stb : Signal()
             Write strobe. Fields should update their value or perform the write side effect when
             this strobe is asserted.
-
-        Raises
-        ------
-        See :meth:`FieldPort.Signature.check_parameters`.
         """
         def __init__(self, shape, access):
-            self.check_parameters(shape, access)
+            try:
+                Shape.cast(shape)
+            except TypeError as e:
+                raise TypeError(f"Field shape must be a shape-castable object, not {shape!r}") from e
+            # TODO(py3.9): Remove this. Python 3.8 and below use cls.__name__ in the error message
+            # instead of cls.__qualname__.
+            # FieldPort.Access(access)
+            try:
+                FieldPort.Access(access)
+            except ValueError as e:
+                raise ValueError(f"{access!r} is not a valid FieldPort.Access") from e
+
             self._shape  = Shape.cast(shape)
             self._access = FieldPort.Access(access)
 
@@ -75,29 +82,6 @@ class FieldPort(wiring.PureInterface):
         @property
         def access(self):
             return self._access
-
-        @classmethod
-        def check_parameters(cls, shape, access):
-            """Validate signature parameters.
-
-            Raises
-            ------
-            :exc:`TypeError`
-                If ``shape`` is not a shape-castable object.
-            :exc:`ValueError`
-                If ``access`` is not a member of :class:`FieldPort.Access`.
-            """
-            try:
-                Shape.cast(shape)
-            except TypeError as e:
-                raise TypeError(f"Field shape must be a shape-castable object, not {shape!r}") from e
-            # TODO(py3.9): Remove this. Python 3.8 and below use cls.__name__ in the error message
-            # instead of cls.__qualname__.
-            # FieldPort.Access(access)
-            try:
-                FieldPort.Access(access)
-            except ValueError as e:
-                raise ValueError(f"{access!r} is not a valid FieldPort.Access") from e
 
         def create(self, *, path=None, src_loc_at=0):
             """Create a compatible interface.

--- a/amaranth_soc/event.py
+++ b/amaranth_soc/event.py
@@ -27,13 +27,16 @@ class Source(wiring.PureInterface):
             Input line. Sampled in order to detect an event.
         trg : Signal()
             Event trigger. Asserted when an event occurs, according to the trigger mode.
-
-        Raises
-        ------
-        See :meth:`Source.Signature.check_parameters`.
         """
         def __init__(self, *, trigger="level"):
-            self.check_parameters(trigger=trigger)
+            # TODO(py3.9): Remove this. Python 3.8 and below use cls.__name__ in the error message
+            # instead of cls.__qualname__.
+            # Source.Trigger(trigger)
+            try:
+                Source.Trigger(trigger)
+            except ValueError as e:
+                raise ValueError(f"{trigger!r} is not a valid Source.Trigger") from e
+
             super().__init__({
                 "i":   Out(1),
                 "trg": In(1),
@@ -43,22 +46,6 @@ class Source(wiring.PureInterface):
         @property
         def trigger(self):
             return self._trigger
-
-        def check_parameters(cls, *, trigger):
-            """Validate signature parameters.
-
-            Raises
-            ------
-            :exc:`ValueError`
-                If ``trigger`` is not a member of :class:`Source.Trigger`.
-            """
-            # TODO(py3.9): Remove this. Python 3.8 and below use cls.__name__ in the error message
-            # instead of cls.__qualname__.
-            # Source.Trigger(trigger)
-            try:
-                Source.Trigger(trigger)
-            except ValueError as e:
-                raise ValueError(f"{trigger!r} is not a valid Source.Trigger") from e
 
         def create(self, *, path=None, src_loc_at=0):
             """Create a compatible interface.
@@ -94,10 +81,6 @@ class Source(wiring.PureInterface):
     ----------
     event_map : :class:`EventMap`
         A collection of event sources.
-
-    Raises
-    ------
-    See :meth:`Source.Signature.check_parameters`.
     """
     def __init__(self, *, trigger="level", path=None, src_loc_at=0):
         super().__init__(Source.Signature(trigger=trigger), path=path, src_loc_at=1 + src_loc_at)

--- a/tests/test_csr_bus.py
+++ b/tests/test_csr_bus.py
@@ -131,14 +131,11 @@ class SignatureTestCase(unittest.TestCase):
         with self.assertRaisesRegex(TypeError,
                 r"Address width must be a positive integer, not -1"):
             csr.Signature(addr_width=-1, data_width=8)
-        with self.assertRaisesRegex(TypeError,
-                r"Address width must be a positive integer, not -1"):
-            csr.Signature.check_parameters(addr_width=-1, data_width=8)
 
     def test_wrong_data_width(self):
         with self.assertRaisesRegex(TypeError,
                 r"Data width must be a positive integer, not -1"):
-            csr.Signature.check_parameters(addr_width=16, data_width=-1)
+            csr.Signature(addr_width=16, data_width=-1)
 
 
 class InterfaceTestCase(unittest.TestCase):

--- a/tests/test_wishbone_bus.py
+++ b/tests/test_wishbone_bus.py
@@ -106,44 +106,25 @@ class SignatureTestCase(unittest.TestCase):
         with self.assertRaisesRegex(TypeError,
                 r"Address width must be a non-negative integer, not -1"):
             wishbone.Signature(addr_width=-1, data_width=8)
-        with self.assertRaisesRegex(TypeError,
-                r"Address width must be a non-negative integer, not -1"):
-            wishbone.Signature.check_parameters(addr_width=-1, data_width=8, granularity=8,
-                                                features=())
 
     def test_wrong_data_width(self):
         with self.assertRaisesRegex(ValueError,
                 r"Data width must be one of 8, 16, 32, 64, not 7"):
             wishbone.Signature(addr_width=0, data_width=7)
-        with self.assertRaisesRegex(ValueError,
-                r"Data width must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature.check_parameters(addr_width=0, data_width=7, granularity=7,
-                                                features=())
 
     def test_wrong_granularity(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity must be one of 8, 16, 32, 64, not 7"):
             wishbone.Signature(addr_width=0, data_width=32, granularity=7)
-        with self.assertRaisesRegex(ValueError,
-                r"Granularity must be one of 8, 16, 32, 64, not 7"):
-            wishbone.Signature.check_parameters(addr_width=0, data_width=32, granularity=7,
-                                                features=())
 
     def test_wrong_granularity_wide(self):
         with self.assertRaisesRegex(ValueError,
                 r"Granularity 32 may not be greater than data width 8"):
             wishbone.Signature(addr_width=0, data_width=8, granularity=32)
-        with self.assertRaisesRegex(ValueError,
-                r"Granularity 32 may not be greater than data width 8"):
-            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=32,
-                                                features=())
 
     def test_wrong_features(self):
         with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
             wishbone.Signature(addr_width=0, data_width=8, features={"foo"})
-        with self.assertRaisesRegex(ValueError, r"'foo' is not a valid Feature"):
-            wishbone.Signature.check_parameters(addr_width=0, data_width=8, granularity=8,
-                                                features={"foo"})
 
 
 class InterfaceTestCase(unittest.TestCase):


### PR DESCRIPTION
Since RFC 38, the signature of a component can only be assigned within its constructor. It is no longer useful to decouple the validation of signature parameters from its constructor.