### PR TITLE
Implement RFC 70: unify naming of `MemoryMap` resources and windows.

### DIFF
--- a/amaranth_soc/csr/event.py
+++ b/amaranth_soc/csr/event.py
@@ -42,8 +42,6 @@ class EventMonitor(wiring.Component):
         CSR bus data width. See :class:`..csr.Interface`.
     alignment : int, power-of-2 exponent
         CSR address alignment. See :class:`..memory.MemoryMap`.
-    name : str
-        Window name. Optional. See :class:`..memory.MemoryMap`.
 
     Attributes
     ----------
@@ -75,9 +73,7 @@ class EventMonitor(wiring.Component):
             "src": Out(self._monitor.src.signature),
             "bus": In(self._mux.bus.signature),
         })
-        self.bus.memory_map = MemoryMap(addr_width=addr_width, data_width=data_width,
-                                        alignment=alignment, name=name)
-        self.bus.memory_map.add_window(self._mux.bus.memory_map)
+        self.bus.memory_map = self._mux.bus.memory_map
 
     def elaborate(self, platform):
         m = Module()

--- a/amaranth_soc/csr/wishbone.py
+++ b/amaranth_soc/csr/wishbone.py
@@ -29,8 +29,8 @@ class WishboneCSRBridge(wiring.Component):
         CSR bus driven by the bridge.
     data_width : int
         Wishbone bus data width. Optional. If ``None``, defaults to ``csr_bus.data_width``.
-    name : str
-        Window name. Optional. See :class:`..memory.MemoryMap`.
+    name : :class:`..memory.MemoryMap.Name`
+        Window name. Optional.
 
     Attributes
     ----------
@@ -59,10 +59,10 @@ class WishboneCSRBridge(wiring.Component):
         super().__init__({"wb_bus": In(wb_sig)})
 
         self.wb_bus.memory_map = MemoryMap(addr_width=csr_bus.addr_width,
-                                           data_width=csr_bus.data_width, name=name)
+                                           data_width=csr_bus.data_width)
         # Since granularity of the Wishbone interface matches the data width of the CSR bus,
         # no width conversion is performed, even if the Wishbone data width is greater.
-        self.wb_bus.memory_map.add_window(csr_bus.memory_map)
+        self.wb_bus.memory_map.add_window(csr_bus.memory_map, name=name)
 
         self._csr_bus = csr_bus
 

--- a/amaranth_soc/gpio.py
+++ b/amaranth_soc/gpio.py
@@ -237,8 +237,6 @@ class Peripheral(wiring.Component):
         CSR bus address width.
     data_width : :class:`int`
         CSR bus data width.
-    name : :class:`str`
-        CSR bus window name. Optional.
     input_stages : :class:`int`
         Number of synchronization stages between pin inputs and the :class:`~Peripheral.Input`
         register. Optional. Defaults to ``2``.
@@ -259,13 +257,13 @@ class Peripheral(wiring.Component):
     :exc:`TypeError`
         If ``input_stages`` is not a non-negative integer.
     """
-    def __init__(self, *, pin_count, addr_width, data_width, name=None, input_stages=2):
+    def __init__(self, *, pin_count, addr_width, data_width, input_stages=2):
         if not isinstance(pin_count, int) or pin_count <= 0:
             raise TypeError(f"Pin count must be a positive integer, not {pin_count!r}")
         if not isinstance(input_stages, int) or input_stages < 0:
             raise TypeError(f"Input stages must be a non-negative integer, not {input_stages!r}")
 
-        regs = csr.Builder(addr_width=addr_width, data_width=data_width, name=name)
+        regs = csr.Builder(addr_width=addr_width, data_width=data_width)
 
         self._mode   = regs.add("Mode",   self.Mode(pin_count))
         self._input  = regs.add("Input",  self.Input(pin_count))

--- a/tests/test_csr_bus.py
+++ b/tests/test_csr_bus.py
@@ -206,30 +206,30 @@ class MultiplexerTestCase(unittest.TestCase):
         map_0 = MemoryMap(addr_width=1, data_width=8)
         map_0.add_resource(_Reg({"foo": Out(csr.Element.Signature(8, "rw"))}), name=("a",), size=1)
         with self.assertRaisesRegex(AttributeError,
-                r"Signature of CSR register \('a',\) must have a csr\.Element\.Signature member "
-                r"named 'element' and oriented as wiring\.Out"):
+                r"Signature of CSR register Name\('a'\) must have a csr\.Element\.Signature "
+                r"member named 'element' and oriented as wiring\.Out"):
             csr.Multiplexer(map_0)
         # wrong direction
         map_1 = MemoryMap(addr_width=1, data_width=8)
         map_1.add_resource(_Reg({"element": In(csr.Element.Signature(8, "rw"))}), name=("a",),
                            size=1)
         with self.assertRaisesRegex(AttributeError,
-                r"Signature of CSR register \('a',\) must have a csr\.Element\.Signature member "
-                r"named 'element' and oriented as wiring\.Out"):
+                r"Signature of CSR register Name\('a'\) must have a csr\.Element\.Signature "
+                r"member named 'element' and oriented as wiring\.Out"):
             csr.Multiplexer(map_1)
         # wrong member type
         map_2 = MemoryMap(addr_width=1, data_width=8)
         map_2.add_resource(_Reg({"element": Out(unsigned(8))}), name=("a",), size=1)
         with self.assertRaisesRegex(AttributeError,
-                r"Signature of CSR register \('a',\) must have a csr\.Element\.Signature member "
-                r"named 'element' and oriented as wiring\.Out"):
+                r"Signature of CSR register Name\('a'\) must have a csr\.Element\.Signature "
+                r"member named 'element' and oriented as wiring\.Out"):
             csr.Multiplexer(map_2)
         # wrong member signature
         map_3 = MemoryMap(addr_width=1, data_width=8)
         map_3.add_resource(_Reg({"element": Out(wiring.Signature({}))}), name=("a",), size=1)
         with self.assertRaisesRegex(AttributeError,
-                r"Signature of CSR register \('a',\) must have a csr\.Element\.Signature member "
-                r"named 'element' and oriented as wiring\.Out"):
+                r"Signature of CSR register Name\('a'\) must have a csr\.Element\.Signature "
+                r"member named 'element' and oriented as wiring\.Out"):
             csr.Multiplexer(map_3)
 
     def test_wrong_memory_map_windows(self):


### PR DESCRIPTION
Fixes #69.