### PR TITLE
WishboneSRAM support for single-port RAM

### DIFF
--- a/amaranth_soc/wishbone/sram.py
+++ b/amaranth_soc/wishbone/sram.py
@@ -106,6 +106,7 @@ class WishboneSRAM(wiring.Component):
         with m.Elif(self.wb_bus.cyc & self.wb_bus.stb):
             if self.writable:
                 m.d.comb += write_port.en.eq(Mux(self.wb_bus.we, self.wb_bus.sel, 0))
+                m.d.comb += read_port.en.eq(~self.wb_bus.we)
             m.d.sync += self.wb_bus.ack.eq(1)
 
         return m

--- a/tests/test_wishbone_sram.py
+++ b/tests/test_wishbone_sram.py
@@ -91,7 +91,6 @@ class WishboneSRAMTestCase(unittest.TestCase):
                 ctx.set(dut.wb_bus.dat_w, (i << 24) | 0x00ffff00)
                 await ctx.tick()
                 self.assertEqual(ctx.get(dut.wb_bus.ack), 1)
-                self.assertEqual(ctx.get(dut.wb_bus.dat_r), i)
                 await ctx.tick()
                 self.assertEqual(ctx.get(dut.wb_bus.ack), 0)
                 ctx.set(dut.wb_bus.cyc, 0)
@@ -115,7 +114,6 @@ class WishboneSRAMTestCase(unittest.TestCase):
                 ctx.set(dut.wb_bus.dat_w, i | 0x00ffff00)
                 await ctx.tick()
                 self.assertEqual(ctx.get(dut.wb_bus.ack), 1)
-                self.assertEqual(ctx.get(dut.wb_bus.dat_r), i << 24)
                 await ctx.tick()
                 self.assertEqual(ctx.get(dut.wb_bus.ack), 0)
 


### PR DESCRIPTION
`WishboneSRAM` can never service a read and a write request at the same time, so it's possible to improve support for SPRAM by disabling the read port when the write-enable is set.

This stops interfering with SPRAM inference where the underlying `Memory` primitive could otherwise match one.